### PR TITLE
Fix flush and asynchronous reset on the fly testing

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,7 +7,7 @@ package:
 
 dependencies:
   cva6        : { git: "https://github.com/openhwgroup/cva6.git", rev: 3868a61} # branch master
-  core-v-verif: { git: "https://github.com/openhwgroup/core-v-verif.git", rev: 13a6c80} # branch master
+  core-v-verif: { git: "https://github.com/openhwgroup/core-v-verif.git", rev: master}
 
 sources:
   -

--- a/env/fpu_env.svh
+++ b/env/fpu_env.svh
@@ -82,6 +82,7 @@ class fpu_env extends uvm_env;
 
         m_fpu_agent.m_monitor.ap_fpu_req.connect(m_fpu_sb.af_fpu_req.analysis_export );
         m_fpu_agent.m_monitor.ap_fpu_rsp.connect(m_fpu_sb.af_fpu_rsp.analysis_export );
+        m_fpu_agent.m_monitor.ap_flush.connect(m_fpu_sb.af_flush.analysis_export );
 
         m_flush_driver.m_pulse_cfg = m_flush_cfg;
         m_fpu_sb.m_sequencer = m_fpu_agent.m_sequencer;

--- a/env/fpu_env.svh
+++ b/env/fpu_env.svh
@@ -86,6 +86,7 @@ class fpu_env extends uvm_env;
 
         m_flush_driver.m_pulse_cfg = m_flush_cfg;
         m_fpu_sb.m_sequencer = m_fpu_agent.m_sequencer;
+        m_fpu_sb.num_txn = m_fpu_top_cfg.get_num_txn();
         `uvm_info(get_full_name( ), "Connect phase complete.", UVM_DEBUG)
     endfunction: connect_phase
 

--- a/env/fpu_sb.svh
+++ b/env/fpu_sb.svh
@@ -38,6 +38,9 @@ class fpu_sb extends uvm_scoreboard;
     // Receives the response sent by the DUV
     uvm_tlm_analysis_fifo #(fpu_rsp_t) af_fpu_rsp;
 
+    // Flush detection
+    uvm_tlm_analysis_fifo #(bit) af_flush;
+
     fpu_req_t q_fpu_req[ logic [CVA6Cfg.TRANS_ID_BITS-1:0] ];
 
     // -------------------------------------------------------------------------
@@ -46,11 +49,10 @@ class fpu_sb extends uvm_scoreboard;
     event reset_asserted;
     event reset_deasserted;
 
-    int req_cnt;  // Request  counter
+    protected int req_cnt;  // Request  counter
     int rsp_cnt; // Response counter
-
-    virtual pulse_if flush_vif;
-    pulse_gen_driver flush_driver;
+    bit all_done; // Flag to signal that all requests have been executed (received corresponding responses)
+    int num_txn; // Number of transactions in a sequence
 
     // -----------------------------------------------------------------------
     // Reference model handle
@@ -70,6 +72,11 @@ class fpu_sb extends uvm_scoreboard;
       
       af_fpu_req = new("af_fpu_req", this);
       af_fpu_rsp = new("af_fpu_rsp", this);
+      af_flush = new("af_flush", this);
+
+      if (!$value$plusargs("NB_TXNS=%d", num_txn )) begin
+        num_txn = 10000;
+      end
     endfunction: new
 
     // -------------------------------------------------------------------------
@@ -77,9 +84,7 @@ class fpu_sb extends uvm_scoreboard;
     // -------------------------------------------------------------------------
     function void build_phase(uvm_phase phase);
       super.build_phase(phase);
-
       m_ref_model = new;
-
       `uvm_info("SCOREBOARD", "Build stage complete.", UVM_MEDIUM)
     endfunction: build_phase
 
@@ -101,6 +106,8 @@ class fpu_sb extends uvm_scoreboard;
       m_sequencer.q_inflight_tid.delete();
 
       req_cnt = 0;
+      rsp_cnt = 0;
+      all_done = 1'b0;
 
       `uvm_info("SCOREBOARD", "Reset stage complete.", UVM_MEDIUM)
     endtask: reset_phase
@@ -130,15 +137,18 @@ class fpu_sb extends uvm_scoreboard;
     // Flushes environment
     // -------------------------------------------------------------------------
     virtual task flush_env();
-      forever begin
-        @(posedge flush_vif.m_pulse_out);
-        `uvm_info("FPU SB", "Flush asserted", UVM_LOW);
-        @(negedge flush_vif.m_pulse_out);
-        `uvm_info("FPU SB", "Flush de-asserted", UVM_LOW);
+      bit flush;
 
-        // Empty all lists
+      forever begin
+        // Blocking until flush is received
+        af_flush.get(flush);
+
+        `uvm_info("FPU SB", "Flushing in-flight requests", UVM_LOW);
+        
         q_fpu_req.delete();
-        m_sequencer.q_inflight_tid.delete();
+        m_sequencer.q_inflight_tid.delete();        
+        req_cnt = 0;
+        all_done = 0;  
       end
     endtask 
 
@@ -193,6 +203,17 @@ class fpu_sb extends uvm_scoreboard;
           end
           // Verification is done, free entry
           q_fpu_req.delete(rsp.trans_id);
+          // Increment response counter
+          rsp_cnt++;
+          // -------------------------------------------------------
+          // Drive all_done when every sent request has been responded to
+          // and there are no more in-flight requests pending
+          // -------------------------------------------------------
+          if ((rsp_cnt == num_txn)) begin
+            all_done = 1'b1;
+            `uvm_info("FPU SB", $sformatf("all_done: cumulative rsp=%0d/%0d",
+              rsp_cnt, num_txn), UVM_HIGH)
+          end
         end else begin
           `uvm_error("FPU_SB_ERR", $sformatf("TID = %0h. No corresponding request", rsp.trans_id));
         end
@@ -205,5 +226,4 @@ class fpu_sb extends uvm_scoreboard;
     function int get_req_counter();
       return req_cnt;
     endfunction 
-
 endclass: fpu_sb

--- a/env/fpu_sb.svh
+++ b/env/fpu_sb.svh
@@ -74,9 +74,6 @@ class fpu_sb extends uvm_scoreboard;
       af_fpu_rsp = new("af_fpu_rsp", this);
       af_flush = new("af_flush", this);
 
-      if (!$value$plusargs("NB_TXNS=%d", num_txn )) begin
-        num_txn = 10000;
-      end
     endfunction: new
 
     // -------------------------------------------------------------------------
@@ -126,11 +123,14 @@ class fpu_sb extends uvm_scoreboard;
     // -------------------------------------------------------------------------
     virtual task main_phase(uvm_phase phase);
       super.main_phase(phase);
-      fork
-        collect_fpu_req();
-        collect_fpu_resp();
-        flush_env();
-      join_none
+      forever begin
+        fork
+          collect_fpu_req();
+          collect_fpu_resp();
+          flush_env();
+        join_any
+        disable fork;
+      end
     endtask: main_phase
 
     // -------------------------------------------------------------------------
@@ -139,17 +139,14 @@ class fpu_sb extends uvm_scoreboard;
     virtual task flush_env();
       bit flush;
 
-      forever begin
-        // Blocking until flush is received
-        af_flush.get(flush);
+      // Blocking until flush is received
+      af_flush.get(flush);
 
-        `uvm_info("FPU SB", "Flushing in-flight requests", UVM_LOW);
-        
-        q_fpu_req.delete();
-        m_sequencer.q_inflight_tid.delete();        
-        req_cnt = 0;
-        all_done = 0;  
-      end
+      `uvm_info("FPU SB", "Flushing in-flight requests", UVM_LOW);
+      q_fpu_req.delete();
+      m_sequencer.q_inflight_tid.delete();        
+      req_cnt = 0;
+      all_done = 0;  
     endtask 
 
     // -------------------------------------------------------------------------

--- a/env/fpu_top_cfg.svh
+++ b/env/fpu_top_cfg.svh
@@ -30,12 +30,19 @@ class fpu_top_cfg extends uvm_object;
 
     rand bit m_reset_on_the_fly;
     rand bit m_flush_on_the_fly;
-        
+    // Number of transactions in a sequence
+    int num_txn;
+
     // ------------------------------------------------------------------------
     // Constructor
     // ------------------------------------------------------------------------
     function new(string name = "fpu_top_cfg");
         super.new(name);
+
+        if (!$value$plusargs("NB_TXNS=%d", num_txn )) begin
+            num_txn = 10000;
+        end
+      `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );
     endfunction
 
     // ---------------------------------------------
@@ -47,6 +54,10 @@ class fpu_top_cfg extends uvm_object;
 
     virtual function bit get_flush_on_the_fly();
         return m_flush_on_the_fly;
+    endfunction
+
+    virtual function int get_num_txn();
+        return num_txn;
     endfunction
 
     // ------------------------------------------------------------------------

--- a/fpu_agent/fpu_agent.svh
+++ b/fpu_agent/fpu_agent.svh
@@ -43,6 +43,7 @@ class fpu_agent extends uvm_agent;
     fpu_monitor   m_monitor;
 
     virtual fpu_if fpu_vif;
+    virtual pulse_if flush_vif;
     
     // -------------------------------------------------------------------------
     // Constructor
@@ -65,7 +66,11 @@ class fpu_agent extends uvm_agent;
         end
 
         if (!uvm_config_db #( virtual fpu_if)::get(this, "", "fpu_vif", fpu_vif )) begin
-            `uvm_fatal("BUILD_PHASE", $psprintf("Unable to get fpu_vif_config for %s from configuration database", get_name() ) );
+            `uvm_fatal("BUILD_PHASE", $psprintf("Unable to get fpu_vif for %s from configuration database", get_name() ) );
+        end
+
+        if (!uvm_config_db #( virtual pulse_if)::get(this, "", "flush_driver", flush_vif )) begin
+            `uvm_fatal("BUILD_PHASE", $psprintf("Unable to get flush_driver for %s from configuration database", get_name() ) );
         end
 
         `uvm_info(get_full_name( ), "Build stage complete.", UVM_LOW)
@@ -77,10 +82,13 @@ class fpu_agent extends uvm_agent;
     function void connect_phase(uvm_phase phase);
         if(is_active == UVM_ACTIVE) begin
             m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
+            m_monitor.ap_flush.connect(m_sequencer.flush_export);
             m_driver.set_fpu_vif(fpu_vif);
+            m_driver.set_flush_vif(flush_vif);
             m_monitor.m_sequencer = m_sequencer; 
         end
         m_monitor.set_fpu_vif(fpu_vif);
+        m_monitor.set_flush_vif(flush_vif);
         `uvm_info(get_full_name( ), "Connect stage complete.", UVM_LOW)
     endfunction: connect_phase
 

--- a/fpu_agent/fpu_driver.svh
+++ b/fpu_agent/fpu_driver.svh
@@ -36,7 +36,8 @@ class fpu_driver extends uvm_driver #(fpu_txn);
     // ------------------------------------------------------------------------
     // Virtual interface
     // -----------------------------------------------------------------------
-    virtual fpu_if fpu_vif;
+    virtual fpu_if   fpu_vif;
+    virtual pulse_if flush_vif;
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -80,10 +81,34 @@ class fpu_driver extends uvm_driver #(fpu_txn);
     // -------------------------------------------------------------------------
     virtual task main_phase(uvm_phase phase);
         super.main_phase(phase);
-        fork
-            get_and_drive();
-        join_none
-        
+        forever begin
+            fork
+                get_and_drive();
+                begin: FLUSH_THREAD
+                    // Polling for a flush
+                    @(posedge fpu_vif.clk_i iff flush_vif.m_pulse_out === 1'b1);
+                end
+            join_any
+            disable fork;
+
+            `uvm_info("FPU DRIVER", "Outside of fork: Flush detected, reset DUT interface to its reset state", UVM_HIGH)
+
+            // Reset DUT interface to its reset state
+            fpu_vif.fpu_valid_i         <= 1'b0;
+            fpu_vif.fu_data_i.fu        <= FPU;
+            fpu_vif.fu_data_i.operation <= FADD;
+            fpu_vif.fu_data_i.operand_a <= '0;
+            fpu_vif.fu_data_i.operand_b <= '0;
+            fpu_vif.fu_data_i.imm       <= '0;
+            fpu_vif.fu_data_i.trans_id  <= '0;
+            fpu_vif.fpu_fmt_i           <= '0;
+            fpu_vif.fpu_frm_i           <= '0;
+            fpu_vif.fpu_rm_i            <= '0;
+            fpu_vif.fpu_prec_i          <= '0;
+
+            @(posedge fpu_vif.clk_i iff flush_vif.m_pulse_out === 1'b0);
+            `uvm_info("FPU DRIVER", "Flush complete", UVM_HIGH)
+        end
     endtask: main_phase
 
     // -------------------------------------------------------------------------
@@ -135,6 +160,8 @@ class fpu_driver extends uvm_driver #(fpu_txn);
         fpu_vif = I;
     endfunction
 
-    
+    function void set_flush_vif (virtual pulse_if I);
+        flush_vif = I;
+    endfunction
 endclass: fpu_driver
 

--- a/fpu_agent/fpu_if.sv
+++ b/fpu_agent/fpu_if.sv
@@ -41,6 +41,7 @@ import fpu_common_pkg::*;
     logic       [CVA6Cfg.TRANS_ID_BITS-1:0] fpu_trans_id_o;
     logic       [         CVA6Cfg.FLen-1:0] result_o;
     exception_t                             fpu_exception_o;
+    logic                                   fpu_early_valid_o;
 
   // ------------------------------------------------------------------------
   // Delay Task

--- a/fpu_agent/fpu_monitor.svh
+++ b/fpu_agent/fpu_monitor.svh
@@ -34,6 +34,7 @@ class fpu_monitor extends uvm_monitor;
     protected uvm_active_passive_enum is_active = UVM_PASSIVE;
 
     virtual fpu_if                   fpu_vif;
+    virtual pulse_if                 flush_vif;
 
     int                              num_req_pkts;
     int                              num_resp_pkts;
@@ -49,6 +50,11 @@ class fpu_monitor extends uvm_monitor;
     // -------------------------------------------------------------------------
     uvm_analysis_port #(fpu_rsp_t) ap_fpu_rsp;
     fpu_rsp_t                      m_rsp_packet;
+
+    // -------------------------------------------------------------------------
+    // Analysis port for flush handling
+    // -------------------------------------------------------------------------
+    uvm_analysis_port #(bit)        ap_flush;
 
     // -------------------------------------------------------------------------
     // Sequencer used to clean the inflight id list
@@ -76,6 +82,7 @@ class fpu_monitor extends uvm_monitor;
 
         ap_fpu_req  = new("ap_fpu_req", this);
         ap_fpu_rsp = new("ap_fpu_rsp", this);
+        ap_flush = new("ap_flush", this);
 
         num_req_pkts        = 0;
         num_resp_pkts       = 0;
@@ -114,11 +121,20 @@ class fpu_monitor extends uvm_monitor;
     // -------------------------------------------------------------------------
     virtual task main_phase(uvm_phase phase);
         `uvm_info("FPU MONITOR", "Entering Main Phase", UVM_HIGH);
-        fork
-            collect_reqs();
-            collect_resps();
-        join_none
-        `uvm_info("FPU MONITOR", "Leaving Main Phase", UVM_HIGH);
+        forever begin
+            fork
+                collect_reqs();
+                collect_resps();
+                begin: FLUSH_THREAD
+                    // Polling for a flush
+                    @(posedge fpu_vif.clk_i iff flush_vif.m_pulse_out === 1'b1);
+                    `uvm_info("FPU MONITOR", "Outside of fork: Flush detected", UVM_HIGH)
+                end
+                flush_detect();
+            join_any
+            disable fork;
+            @(posedge fpu_vif.clk_i iff flush_vif.m_pulse_out === 1'b0);
+        end
     endtask: main_phase
 
     // -------------------------------------------------------------------------
@@ -150,7 +166,7 @@ class fpu_monitor extends uvm_monitor;
     // -------------------------------------------------------------------------
     // Collect responses
     // -------------------------------------------------------------------------
-    task collect_resps();
+    virtual task collect_resps();
         fpu_rsp_t rsp;
 
         forever begin
@@ -171,6 +187,17 @@ class fpu_monitor extends uvm_monitor;
                 num_resp_pkts++;
             end
         end
+    endtask
+
+    // -------------------------------------------------------------------------
+    // Monitor flush signal
+    // -------------------------------------------------------------------------
+    virtual task flush_detect();
+        @(posedge fpu_vif.clk_i iff flush_vif.m_pulse_out === 1'b1);
+        `uvm_info("FPU MONITOR", "Flush detected", UVM_HIGH);
+
+        // Notify sequencer and scoreboard of flush
+        ap_flush.write(1'b1);
     endtask
 
     // -------------------------------------------------------------------------
@@ -195,4 +222,7 @@ class fpu_monitor extends uvm_monitor;
         fpu_vif = I;
     endfunction
 
+    function void set_flush_vif (virtual pulse_if I);
+        flush_vif = I;
+    endfunction
 endclass: fpu_monitor

--- a/fpu_agent/fpu_sequencer.svh
+++ b/fpu_agent/fpu_sequencer.svh
@@ -24,7 +24,11 @@
  *  History       :
  */
 
+`uvm_analysis_imp_decl(_flush)
+
 class fpu_sequencer extends uvm_sequencer #(fpu_txn, fpu_txn);
+
+  uvm_analysis_imp_flush #(bit, fpu_sequencer) flush_export;
 
   // -------------------------------------------------------
   // List of in-flight transactions' IDs
@@ -40,5 +44,18 @@ class fpu_sequencer extends uvm_sequencer #(fpu_txn, fpu_txn);
       super.new(name, parent);
       
   endfunction: new
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    flush_export = new("flush_export", this);
+  endfunction
   
+  // -------------------------------------------------------------------------
+  // Called automatically when monitor writes to ap_flush
+  // -------------------------------------------------------------------------
+  virtual function void write_flush(bit t);
+    // Stop any running sequences
+    stop_sequences();
+
+  endfunction
 endclass: fpu_sequencer

--- a/fpu_agent/fpu_sequences.svh
+++ b/fpu_agent/fpu_sequences.svh
@@ -47,12 +47,6 @@ class fpu_base_sequence extends uvm_sequence #(fpu_txn);
     function new( string name = "base_data_txn_sequence" );
         super.new(name);
 
-        if (!$value$plusargs("NB_TXNS=%d", num_txn )) begin
-            num_txn = 10000;
-        end // if
-        
-        `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );
-
         // Enable response handler
         use_response_handler(1);
     endfunction: new
@@ -70,6 +64,10 @@ class fpu_base_sequence extends uvm_sequence #(fpu_txn);
 
     function void set_op_group (input int op_group_cfg);
         this.op_group_cfg = op_group_cfg;
+    endfunction
+
+    function void set_num_txn(input int num_txn);
+        this.num_txn = num_txn;
     endfunction
  
     // If the id list if full, it waits until an id is freed 
@@ -378,61 +376,67 @@ class fpu_unit_seq extends  fpu_base_sequence;
 
         item = fpu_txn::type_id::create("fpu single request");
 
-        // --------------------------------------------------------------------------------
-        // to generate unique TID a list of tid in flight is passed on to the sequence
-        // --------------------------------------------------------------------------------
-        item.q_inflight_tid = my_sequencer.q_inflight_tid;
+        for (int i = 0; i < num_txn; i++) begin
+            // --------------------------------------------------------------------------------
+            // to generate unique TID a list of tid in flight is passed on to the sequence
+            // --------------------------------------------------------------------------------
+            item.q_inflight_tid = my_sequencer.q_inflight_tid;
 
-        // --------------------------------
-        // Randomize transaction item
-        // --------------------------------
-        if ( !item.randomize() with 
-            {
-                //-----------------------------------------------
-                //  ISSUE #3123 in CVA6
-                m_nan_box == 0;
-                m_operation == FDIV;
-                m_operand_a == 'hc1ddd216;
-                m_operand_b == 'hbae084b4;
-                m_fmt == 0; // 32bits
-                m_imm == 0;
-                //-----------------------------------------------
-                //  ISSUE #145 + PR #147 ( tested and it works )
-                // m_operation == FCVT_F2I;
-                // m_operand_a == 64'hC1E0000000000000;
-                // m_fmt == 1;
-                // m_imm == 0;
-                // m_rm == 0;
-                //-----------------------------------------------
-                // ISSUE #120 -> no error in current version with THMULTI
-                // m_operation == FDIV;
-                // m_operand_a == 'h0;
-                // m_operand_b == 'h7F800000;
-                // m_fmt == 0;
-                //-----------------------------------------------
-                // ISSUE #139 -> no error in current version with THMULTI
-                // m_operation == FDIV;
-                // m_operand_a == 'h7f7fffff;
-                // m_operand_b == 'h3f7fffff;
-                // m_fmt == 0;
-                //-----------------------------------------------
-                // ISSUE #121 -> no error in current version with THMULTI
-                // m_operation == FDIV;
-                // m_operand_a == 'h00000001;
-                // m_operand_b == 'h3F800000;
-                // m_fmt       == 0;
-                //-----------------------------------------------
-            } ) 
-        begin
-            `uvm_fatal("body","Randomization failed");    
+            // --------------------------------
+            // Randomize transaction item
+            // --------------------------------
+            if ( !item.randomize() with 
+                {
+                    m_nan_box == 0;
+                    m_operation inside {FDIV, FSQRT};
+                    m_fmt inside {0,2};
+                    m_imm == 0;
+                    //-----------------------------------------------
+                    //  ISSUE #3123 in CVA6
+                    // m_nan_box == 0;
+                    // m_operation == FDIV;
+                    // m_operand_a == 'hc1ddd216;
+                    // m_operand_b == 'hbae084b4;
+                    // m_fmt == 0; // 32bits
+                    // m_imm == 0;
+                    //-----------------------------------------------
+                    //  ISSUE #145 + PR #147 ( tested and it works )
+                    // m_operation == FCVT_F2I;
+                    // m_operand_a == 64'hC1E0000000000000;
+                    // m_fmt == 1;
+                    // m_imm == 0;
+                    // m_rm == 0;
+                    //-----------------------------------------------
+                    // ISSUE #120 -> no error in current version with THMULTI
+                    // m_operation == FDIV;
+                    // m_operand_a == 'h0;
+                    // m_operand_b == 'h7F800000;
+                    // m_fmt == 0;
+                    //-----------------------------------------------
+                    // ISSUE #139 -> no error in current version with THMULTI
+                    // m_operation == FDIV;
+                    // m_operand_a == 'h7f7fffff;
+                    // m_operand_b == 'h3f7fffff;
+                    // m_fmt == 0;
+                    //-----------------------------------------------
+                    // ISSUE #121 -> no error in current version with THMULTI
+                    // m_operation == FDIV;
+                    // m_operand_a == 'h00000001;
+                    // m_operand_b == 'h3F800000;
+                    // m_fmt       == 0;
+                    //-----------------------------------------------
+                } ) 
+            begin
+                `uvm_fatal("body","Randomization failed");    
+            end
+            // --------------------------------------------------------------------------------
+            // It is used when the response is received from the driver
+            // --------------------------------------------------------------------------------
+            my_sequencer.q_inflight_tid[item.m_trans_id] = item.m_trans_id;
+
+            start_item( item );
+            finish_item( item );
         end
-        // --------------------------------------------------------------------------------
-        // It is used when the response is received from the driver
-        // --------------------------------------------------------------------------------
-        my_sequencer.q_inflight_tid[item.m_trans_id] = item.m_trans_id;
-
-        start_item( item );
-        finish_item( item );
   endtask: body
 
 endclass: fpu_unit_seq

--- a/ref_model_csim/rtl/fpu_refmodel.svh
+++ b/ref_model_csim/rtl/fpu_refmodel.svh
@@ -70,20 +70,20 @@ class fpu_refmodel extends uvm_object;
     INT_WIDTH = int_format ? 64 : 32;
     int_mask  = (1 << INT_WIDTH) - 1;
 
-    src_fp_fmt = operator == FCVT_F2F ? op3[2:0] : txn.fmt;
+    src_fp_fmt = operator == FCVT_F2F ? txn.data.imm[2:0] : txn.fmt;
 
     SRC_FP_WIDTH = fpnew_pkg::fp_width(fpnew_pkg::fp_format_e'(src_fp_fmt));
 
-    fp_mask  = (1 << SRC_FP_WIDTH) - 1;
+    fp_mask  = (1 << (CVA6Cfg.XLEN - SRC_FP_WIDTH)) - 1;
 
     // NaN-box check
     op1_is_boxed = ((op1 & fp_mask<<SRC_FP_WIDTH) >> SRC_FP_WIDTH) == fp_mask;
     op2_is_boxed = ((op2 & fp_mask<<SRC_FP_WIDTH) >> SRC_FP_WIDTH) == fp_mask;
     op3_is_boxed = ((op3 & fp_mask<<SRC_FP_WIDTH) >> SRC_FP_WIDTH) == fp_mask;
 
-    op1 = (op1_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op1 : set_to_qNan(src_fp_fmt, op1);
-    op2 = (op2_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op2 : set_to_qNan(src_fp_fmt, op2);
-    op3 = (op3_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op3 : set_to_qNan(src_fp_fmt, op3);
+    op1 = (op1_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op1 : set_to_cNan(src_fp_fmt, op1);
+    op2 = (op2_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op2 : set_to_cNan(src_fp_fmt, op2);
+    op3 = (op3_is_boxed || (operator inside {FMV_X2F, FMV_F2X, FCVT_I2F})) ? op3 : set_to_cNan(src_fp_fmt, op3);
     
     `uvm_info("FPU_REF_MODEL", 
               $sformatf("TXN INFO: OP=%0s, OP1=%0h (h), OP2=%0h (h), OP3=%0h (h), RND=%0h (h), BIS=%0d (d), ES=%0d (d)", 
@@ -170,9 +170,9 @@ class fpu_refmodel extends uvm_object;
   endfunction
 
   // -----------------------------------------------------------
-  // Set operand to qNaN
+  // Set operand to canonical NaN
   // -----------------------------------------------------------
-  function bit [CVA6Cfg.XLEN-1:0] set_to_qNan (input logic [2:0] fmt, input bit [CVA6Cfg.XLEN-1:0] op);
+  function bit [CVA6Cfg.XLEN-1:0] set_to_cNan (input logic [2:0] fmt, input bit [CVA6Cfg.XLEN-1:0] op);
     bit [CVA6Cfg.XLEN-1:0] res;
 
     res = {CVA6Cfg.XLEN{1'b1}};

--- a/tests/base_test.svh
+++ b/tests/base_test.svh
@@ -41,11 +41,15 @@ class base_test extends uvm_test;
     // -------------------------------------------------
     fpu_base_sequence           base_sequence; 
 
-    int unsigned                clk_cnt_before_rst;
-    int unsigned                nb_trans_before_rst;
-
     // Number of transactions in a sequence
     int                         num_txn;
+
+    // --------------------------------------------------
+    // Internal fields
+    // -------------------------------------------------
+    bit          all_done;      // set when scoreboard signals completion
+    int unsigned clk_cnt_before_rst;  // Number of clock cycles before asserting async reset
+    int unsigned nb_trans_before_rst; // Number of output transactions before asserting async reset
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -78,25 +82,14 @@ class base_test extends uvm_test;
                     get_full_name( ), ".fpu_vif"})
       end
 
-      if(!uvm_config_db #( virtual pulse_if)::get(null, "", "flush_driver", flush_vif ))  begin
-        `uvm_error("NOVIF", {"Unable to get vif from configuration database for: ",
-                    get_full_name( ), ".vif"})
+      if (!uvm_config_db #( virtual pulse_if)::get(this, "", "flush_driver", flush_vif )) begin
+          `uvm_fatal("BUILD_PHASE", $psprintf("Unable to get flush_driver for %s from configuration database", get_name() ) );
       end
 
       base_sequence = fpu_base_sequence::type_id::create("seq");
 
       `uvm_info(get_full_name(), "Build phase complete", UVM_HIGH)
     endfunction: build_phase
-
-    // -------------------------------------------------------------------------
-    // Connect phase
-    // -------------------------------------------------------------------------
-    function void connect_phase(uvm_phase phase);
-      `uvm_info(get_full_name( ), "Connect phase complete.", UVM_LOW)
-
-      env.m_fpu_sb.flush_vif    = flush_vif;
-      env.m_fpu_sb.flush_driver = env.m_flush_driver;
-    endfunction: connect_phase 
 
   // -------------------------------------------------------------------------
   // End of elaboration phase
@@ -130,58 +123,80 @@ class base_test extends uvm_test;
   // -------------------------------------------------------------------------
   virtual task reset_phase( uvm_phase phase );
     clk_cnt_before_rst = 0;
+    all_done = 0;
   endtask
 
   // -------------------------------------------------------------------------
   // Main phase
   // -------------------------------------------------------------------------
   virtual task main_phase(uvm_phase phase);
+    // Compute the number of transactions after which a reset is asserted
+    nb_trans_before_rst = $urandom_range(num_txn/4, num_txn/2);
+    all_done = 0;
+
     super.main_phase( phase );
 
     phase.phase_done.set_drain_time(this, 1500);
-
-    fork
-      // --------------------------------------------------------------
-      // start the base sequence here 
-      // This base sequence needs to be overwritten in the test class 
-      // ---------------------------------------------------------------
-      base_sequence.start(env.m_fpu_agent.m_sequencer);
-    join_none
+    phase.raise_objection(this, "Test started");
     
-    // Compute the number of transactions after which a reset is asserted
-    nb_trans_before_rst = $urandom_range(num_txn/2, num_txn/4);
-
-    if (env.m_fpu_top_cfg.get_reset_on_the_fly()) begin
+    do begin
       fork
-        phase.raise_objection(this, "Start reset asertion");
-        forever begin
-          clk_vif.wait_n_clocks(1);
-          clk_cnt_before_rst++;
-
-          // Assert reset on the fly when condition is met
-          if( (env.m_fpu_sb.get_req_counter() == nb_trans_before_rst) || (clk_cnt_before_rst == 10*num_txn) ) begin	
-            phase.drop_objection(this, "Assert reset");
-            
-            // env.m_fpu_agent.m_sequencer.stop_sequences();
-            env.m_reset_driver.emit_assert_reset();
-          end
-
-          // Break from loop when reset is done
-          if(env.m_reset_driver.get_reset_on_the_fly_done() == 1) begin
-            `uvm_info("RESET ON THE FLY END", $sformatf("%0d(d), %0d(d)",env.m_fpu_sb.get_req_counter(), nb_trans_before_rst ), UVM_DEBUG); 
-            phase.drop_objection(this, "Finish reset assertion");
-            break;
+        // ---------------------------------------
+        // MAIN THREAD
+        // ---------------------------------------
+        begin: MAIN_THREAD
+          `uvm_info(get_full_name(), "Inside main thread", UVM_HIGH)
+          base_sequence.start(env.m_fpu_agent.m_sequencer);
+          // Block until all transactions are executed
+          wait (env.m_fpu_sb.all_done == 1'b1);
+          all_done = 1;
+        end
+        // ---------------------------------------
+        // FLUSH THREAD
+        // ---------------------------------------
+        begin: FLUSH_THREAD
+          `uvm_info(get_full_name(), "Inside flush thread", UVM_HIGH)
+          if ( env.m_fpu_top_cfg.get_flush_on_the_fly() && env.m_flush_driver.m_pulse_cnt < 1) begin
+            // Block until a flush is detected
+            @(env.m_flush_driver.pulse_fired);
+          end else begin
+            // Wait here until all transactions are executed
+            wait (0);
           end
         end
-      join_none
-    end
+        // ---------------------------------------
+        // RESET THREAD
+        // ---------------------------------------
+        begin : RESET_THREAD
+          `uvm_info(get_full_name(), "Inside reset thread", UVM_HIGH)
+          if ( env.m_fpu_top_cfg.get_reset_on_the_fly() && !env.m_reset_driver.get_reset_on_the_fly_done()) begin
+            // Wait until transaction threshold or clock timeout
+            forever begin
+              clk_vif.wait_n_clocks(1);
+              clk_cnt_before_rst++;
 
-    phase.raise_objection(this, "Starting sequences");
-    clk_vif.wait_n_clocks(100000);
-    phase.drop_objection(this, "Completed sequences");
+              // Assert reset on the fly when condition is met
+              if( (env.m_fpu_sb.get_req_counter() == nb_trans_before_rst) || (clk_cnt_before_rst == 10*num_txn) ) begin
+                `uvm_info(get_full_name(), $sformatf("Asserting reset after %0d reqs / %0d clks",
+                                env.m_fpu_sb.get_req_counter(),
+                                clk_cnt_before_rst), UVM_HIGH)
+                env.m_reset_driver.emit_assert_reset();
+                all_done=1; // Break from while loop
+                break; // Break from forever loop
+              end
+            end
+          end else begin
+            // Wait here until all transactions are executed
+            wait (0);
+          end
+        end
+      join_any
+      disable fork;
+      `uvm_info(get_full_name(), "Fork disabled", UVM_HIGH)
+    end while (!all_done);
+
+    phase.drop_objection(this, "Test finished");
 
     `uvm_info(get_full_name(), "Main phase complete", UVM_LOW)
   endtask
-  
-
 endclass: base_test

--- a/tests/base_test.svh
+++ b/tests/base_test.svh
@@ -56,12 +56,6 @@ class base_test extends uvm_test;
     // -------------------------------------------------------------------------
     function new(string name, uvm_component parent);
       super.new(name, parent);
-
-      if (!$value$plusargs("NB_TXNS=%d", num_txn )) begin
-        num_txn = 10000;
-      end // if
-      
-      `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );      
     endfunction: new
 
     // -------------------------------------------------------------------------
@@ -130,6 +124,9 @@ class base_test extends uvm_test;
   // Main phase
   // -------------------------------------------------------------------------
   virtual task main_phase(uvm_phase phase);
+
+    num_txn = env.m_fpu_top_cfg.get_num_txn();
+
     // Compute the number of transactions after which a reset is asserted
     nb_trans_before_rst = $urandom_range(num_txn/4, num_txn/2);
     all_done = 0;
@@ -146,6 +143,7 @@ class base_test extends uvm_test;
         // ---------------------------------------
         begin: MAIN_THREAD
           `uvm_info(get_full_name(), "Inside main thread", UVM_HIGH)
+          base_sequence.set_num_txn(num_txn);
           base_sequence.start(env.m_fpu_agent.m_sequencer);
           // Block until all transactions are executed
           wait (env.m_fpu_sb.all_done == 1'b1);

--- a/tests/base_test.svh
+++ b/tests/base_test.svh
@@ -156,7 +156,7 @@ class base_test extends uvm_test;
         // ---------------------------------------
         begin: FLUSH_THREAD
           `uvm_info(get_full_name(), "Inside flush thread", UVM_HIGH)
-          if ( env.m_fpu_top_cfg.get_flush_on_the_fly() && env.m_flush_driver.m_pulse_cnt < 1) begin
+          if ( env.m_fpu_top_cfg.get_flush_on_the_fly() && env.m_flush_driver.get_pulse_cnt() < 1) begin
             // Block until a flush is detected
             @(env.m_flush_driver.pulse_fired);
           end else begin

--- a/top/rtl/tb_top.sv
+++ b/top/rtl/tb_top.sv
@@ -82,7 +82,7 @@ module top;
         .result_o        ( fpu_vif.result_o       ),
         .fpu_valid_o     ( fpu_vif.fpu_valid_o    ),
         .fpu_exception_o ( fpu_vif.fpu_exception_o ),
-        .fpu_early_valid_o (/*OPEN*/)
+        .fpu_early_valid_o ( fpu_vif.fpu_early_valid_o )
     );
 
     initial begin


### PR DESCRIPTION
### Description
This PR addresses flush and reset on-the-fly testing, improving the handling of both synchronous (flush) and asynchronous reset events across the testbench. These changes fix issue #3 and improve overall functionality. 

### Changes
#### Flush detection and propagation
- Driver and monitor adopt `forever fork/join_any/disable fork` pattern so flush kills active threads cleanly when flush is detected
- Added `ap_flush` analysis port in the monitor and connect it to both scoreboard and sequencer, replacing direct `flush_vif` polling in scoreboard
- Sequencer calls `stop_sequences()` in `write_flush()` to resolve open TLM handshake and prevent driver–sequencer deadlock
- Added `all_done` flag to scoreboard set when `rsp_cnt == num_txn`

#### Update base_test class
- Replaced `fork/join_none` + fixed `wait_n_clocks(100000)` with a `do/while` loop containing three concurrent threads (`MAIN`, `FLUSH`, `RESET`) using `fork/join_any/disable fork`
- Test completion now driven by `scoreboard.all_done` instead of a fixed clock timeout

#### Update reference model
- Bug fix in nan_box logic in `fpu_refmodel.svh`

### Validation
These tests have been validated by running the complete non-regression with 300 seeds for each test.