### PR TITLE
cva6: Bump version to get latest bug fixes in CVFPU

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -6,7 +6,7 @@ package:
     - "Riccardo Giunti"
 
 dependencies:
-  cva6        : { git: "https://github.com/openhwgroup/cva6.git", rev: 3868a61} # branch master
+  cva6        : { git: "https://github.com/openhwgroup/cva6.git", rev: 3f39c6} # branch master
   core-v-verif: { git: "https://github.com/openhwgroup/core-v-verif.git", rev: master}
 
 sources:


### PR DESCRIPTION
This PR bumps the version of the cva6 used in the cvfpu-uvm. It addresses https://github.com/openhwgroup/cvfpu-uvm/issues/10 and fixes regression failures.