### PR TITLE
Fetch CVFPU directly instead of via CVA6 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,5 @@
 	branch = master
 [submodule "modules/cvfpu"]
 	path = modules/cvfpu
-	url = git@github.com:openhwgroup/cvfpu.git
+	url = https://github.com/openhwgroup/cvfpu.git
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,6 @@
 	path = modules/core-v-verif
 	url = https://github.com/openhwgroup/core-v-verif.git
 	branch = master
-[submodule "modules/cva6"]
-	path = modules/cva6
-	url = https://github.com/openhwgroup/cva6.git
-	branch = master
+[submodule "modules/cvfpu"]
+	path = modules/cvfpu
+	url = git@github.com:openhwgroup/cvfpu.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,8 +6,8 @@ package:
     - "Riccardo Giunti"
 
 dependencies:
-  cva6        : { git: "https://github.com/openhwgroup/cva6.git", rev: 3f39c6} # branch master
   core-v-verif: { git: "https://github.com/openhwgroup/core-v-verif.git", rev: master}
+  fpnew: { git: "https://github.com/openhwgroup/cvfpu.git", rev: develop }
 
 sources:
   -
@@ -17,7 +17,14 @@ sources:
       - ref_model_csim/rtl
       - env
       - tests
+      - modules/cva6-cvfpu
     files:
+      - modules/cva6-cvfpu/config_pkg.sv
+      - modules/cva6-cvfpu/build_config_pkg.sv
+      - modules/cva6-cvfpu/cv64a60ax_config_pkg_cvfpu-uvm.sv
+      - modules/cva6-cvfpu/riscv_pkg.sv
+      - modules/cva6-cvfpu/ariane_pkg.sv
+      - modules/cva6-cvfpu/fpu_wrap.sv
       - fpu_common/fpu_common_pkg.sv
       - fpu_agent/fpu_agent_pkg.sv
       - fpu_agent/fpu_if.sv

--- a/modules/cva6-cvfpu/ariane_pkg.sv
+++ b/modules/cva6-cvfpu/ariane_pkg.sv
@@ -1,0 +1,875 @@
+/* Copyright 2018 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the “License”); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * File:   ariane_pkg.sv
+ * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+ * Date:   8.4.2017
+ *
+ * Description: Contains all the necessary defines for Ariane
+ *              in one package.
+ */
+
+// this is needed to propagate the
+// configuration in case Ariane is
+// instantiated in OpenPiton
+`ifdef PITON_ARIANE
+`include "l15.tmp.h"
+`endif
+
+/// This package contains `functions` and global defines for CVA6.
+/// *Note*: There are some parameters here as well which will eventually be
+/// moved out to favour a fully parameterizable core.
+package ariane_pkg;
+
+  // TODO: Slowly move those parameters to the new system.
+  localparam BITS_SATURATION_COUNTER = 2;
+
+  // depth of store-buffers, this needs to be a power of two
+  localparam logic [2:0] DEPTH_SPEC = 'd4;
+
+  // if CVA6Cfg.DCacheType = cva6_config_pkg::WT
+  // we can use a small commit queue since we have a write buffer in the dcache
+  // we could in principle do without the commit queue in this case, but the timing degrades if we do that due
+  // to longer paths into the commit stage
+  // if CVA6Cfg.DCacheType = cva6_config_pkg::WB
+  // allocate more space for the commit buffer to be on the safe side, this needs to be a power of two
+  localparam logic [2:0] DEPTH_COMMIT = 'd4;
+
+  // Transprecision float unit
+  localparam int unsigned LAT_COMP_FP32 = 'd2;
+  localparam int unsigned LAT_COMP_FP64 = 'd3;
+  localparam int unsigned LAT_COMP_FP16 = 'd1;
+  localparam int unsigned LAT_COMP_FP16ALT = 'd1;
+  localparam int unsigned LAT_COMP_FP8 = 'd1;
+  localparam int unsigned LAT_DIVSQRT = 'd2;
+  localparam int unsigned LAT_NONCOMP = 'd1;
+  localparam int unsigned LAT_CONV = 'd2;
+
+  localparam logic [31:0] OPENHWGROUP_MVENDORID = 32'h0602;
+  localparam logic [31:0] ARIANE_MARCHID = 32'd3;
+  localparam logic [31:0] ARIANE_MIMPID = 32'd0;
+
+  // 32 registers
+  localparam REG_ADDR_SIZE = 5;
+
+  // Read ports for general purpose register files
+  localparam NR_RGPR_PORTS = 2;
+
+  // static debug hartinfo
+  // debug causes
+  localparam logic [2:0] CauseBreakpoint = 3'h1;
+  localparam logic [2:0] CauseTrigger = 3'h2;
+  localparam logic [2:0] CauseRequest = 3'h3;
+  localparam logic [2:0] CauseSingleStep = 3'h4;
+  // amount of data count registers implemented
+  localparam logic [3:0] DataCount = 4'h2;
+
+  // address where data0-15 is shadowed or if shadowed in a CSR
+  // address of the first CSR used for shadowing the data
+  localparam logic [11:0] DataAddr = 12'h380;  // we are aligned with Rocket here
+  typedef struct packed {
+    logic [31:24] zero1;
+    logic [23:20] nscratch;
+    logic [19:17] zero0;
+    logic         dataaccess;
+    logic [15:12] datasize;
+    logic [11:0]  dataaddr;
+  } hartinfo_t;
+
+  localparam hartinfo_t DebugHartInfo = '{
+      zero1: '0,
+      nscratch: 2,  // Debug module needs at least two scratch regs
+      zero0: '0,
+      dataaccess: 1'b1,  // data registers are memory mapped in the debugger
+      datasize: DataCount,
+      dataaddr: DataAddr
+  };
+
+  // enables a commit log which matches spikes commit log format for easier trace comparison
+  localparam bit ENABLE_SPIKE_COMMIT_LOG = 1'b1;
+
+  // ------------- Dangerous -------------
+  // if set to zero a flush will not invalidate the cache-lines, in a single core environment
+  // where coherence is not necessary this can improve performance. This needs to be switched on
+  // when more than one core is in a system
+  localparam logic INVALIDATE_ON_FLUSH = 1'b1;
+
+`ifdef SPIKE_TANDEM
+  // Spike still places 0 in TVAL for ENV_CALL_* exceptions.
+  // This may eventually go away when Spike starts to handle TVAL for *all* exceptions.
+  localparam bit ZERO_TVAL = 1'b1;
+`else
+  localparam bit ZERO_TVAL = 1'b0;
+`endif
+
+  // read mask for SSTATUS over MSTATUS
+  function automatic logic [63:0] smode_status_read_mask(config_pkg::cva6_cfg_t Cfg);
+    return riscv::SSTATUS_UIE
+    | riscv::SSTATUS_SIE
+    | riscv::SSTATUS_SPIE
+    | riscv::SSTATUS_UBE
+    | riscv::SSTATUS_SPP
+    | riscv::SSTATUS_FS
+    | riscv::SSTATUS_XS
+    | riscv::SSTATUS_SUM
+    | riscv::SSTATUS_MXR
+    | riscv::SSTATUS_UPIE
+    | riscv::SSTATUS_SPIE
+    | riscv::SSTATUS_UXL
+    | riscv::sstatus_sd(Cfg.IS_XLEN64);
+  endfunction
+
+  localparam logic [63:0] SMODE_STATUS_WRITE_MASK = riscv::SSTATUS_SIE
+                                                    | riscv::SSTATUS_SPIE
+                                                    | riscv::SSTATUS_SPP
+                                                    | riscv::SSTATUS_FS
+                                                    | riscv::SSTATUS_SUM
+                                                    | riscv::SSTATUS_MXR;
+
+  localparam logic [63:0] HSTATUS_WRITE_MASK      = riscv::HSTATUS_VSBE
+                                                    | riscv::HSTATUS_GVA
+                                                    | riscv::HSTATUS_SPV
+                                                    | riscv::HSTATUS_SPVP
+                                                    | riscv::HSTATUS_HU
+                                                    | riscv::HSTATUS_VTVM
+                                                    | riscv::HSTATUS_VTW
+                                                    | riscv::HSTATUS_VTSR;
+
+  // hypervisor delegable interrupts
+  function automatic logic [31:0] hs_deleg_interrupts(config_pkg::cva6_cfg_t Cfg);
+    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP;
+  endfunction
+
+  // virtual supervisor delegable interrupts
+  function automatic logic [31:0] vs_deleg_interrupts(config_pkg::cva6_cfg_t Cfg);
+    return riscv::MIP_VSSIP | riscv::MIP_VSTIP | riscv::MIP_VSEIP;
+  endfunction
+
+  // ---------------
+  // AXI
+  // ---------------
+
+  typedef enum logic {
+    SINGLE_REQ,
+    CACHE_LINE_REQ
+  } ad_req_t;
+
+  // ---------------
+  // Fetch Stage
+  // ---------------
+
+  // leave as is (fails with >8 entries and wider fetch width)
+  localparam int unsigned FETCH_FIFO_DEPTH = 4;
+  localparam int unsigned FETCH_ADDR_FIFO_DEPTH = 2;
+
+  typedef enum logic [2:0] {
+    NoCF,    // No control flow prediction
+    Branch,  // Branch
+    Jump,    // Jump to address from immediate
+    JumpR,   // Jump to address from registers
+    Return   // Return Address Prediction
+  } cf_t;
+
+  typedef struct packed {
+    logic valid;
+    logic taken;
+  } bht_prediction_t;
+
+  typedef struct packed {
+    logic       valid;
+    logic [1:0] saturation_counter;
+  } bht_t;
+
+  typedef enum logic [3:0] {
+    NONE,       // 0
+    LOAD,       // 1
+    STORE,      // 2
+    ALU,        // 3
+    CTRL_FLOW,  // 4
+    MULT,       // 5
+    CSR,        // 6
+    FPU,        // 7
+    FPU_VEC,    // 8
+    CVXIF,      // 9
+    ACCEL,      // 10
+    AES         // 11
+  } fu_t;
+
+  // Index of writeback ports
+  localparam FLU_WB = 0;
+  localparam STORE_WB = 1;
+  localparam LOAD_WB = 2;
+  localparam FPU_WB = 3;
+  localparam ACC_WB = 4;
+  localparam X_WB = 4;
+
+  localparam EXC_OFF_RST = 8'h80;
+
+  localparam SupervisorIrq = 1;
+  localparam MachineIrq = 0;
+
+  // ---------------
+  // Cache config
+  // ---------------
+
+  // for usage in OpenPiton we have to propagate the openpiton L15 configuration from l15.h
+`ifdef PITON_ARIANE
+
+`ifndef CONFIG_L1I_CACHELINE_WIDTH
+  `define CONFIG_L1I_CACHELINE_WIDTH 128
+`endif
+
+`ifndef CONFIG_L1I_ASSOCIATIVITY
+  `define CONFIG_L1I_ASSOCIATIVITY 4
+`endif
+
+`ifndef CONFIG_L1I_SIZE
+  `define CONFIG_L1I_SIZE 16*1024
+`endif
+
+`ifndef CONFIG_L1D_CACHELINE_WIDTH
+  `define CONFIG_L1D_CACHELINE_WIDTH 128
+`endif
+
+`ifndef CONFIG_L1D_ASSOCIATIVITY
+  `define CONFIG_L1D_ASSOCIATIVITY 8
+`endif
+
+`ifndef CONFIG_L1D_SIZE
+  `define CONFIG_L1D_SIZE 32*1024
+`endif
+
+`ifndef L15_THREADID_WIDTH
+  `define L15_THREADID_WIDTH 3
+`endif
+
+  // I$
+  localparam int unsigned ICACHE_LINE_WIDTH = `CONFIG_L1I_CACHELINE_WIDTH;
+  localparam int unsigned ICACHE_SET_ASSOC = `CONFIG_L1I_ASSOCIATIVITY;
+  localparam int unsigned ICACHE_INDEX_WIDTH = $clog2(`CONFIG_L1I_SIZE / ICACHE_SET_ASSOC);
+  localparam int unsigned ICACHE_TAG_WIDTH = riscv::PLEN - ICACHE_INDEX_WIDTH;
+  localparam int unsigned ICACHE_USER_LINE_WIDTH = (AXI_USER_WIDTH == 1) ? 4 : 128;  // in bit
+  // D$
+  localparam int unsigned DCACHE_LINE_WIDTH = `CONFIG_L1D_CACHELINE_WIDTH;
+  localparam int unsigned DCACHE_SET_ASSOC = `CONFIG_L1D_ASSOCIATIVITY;
+  localparam int unsigned DCACHE_INDEX_WIDTH = $clog2(`CONFIG_L1D_SIZE / DCACHE_SET_ASSOC);
+  localparam int unsigned DCACHE_TAG_WIDTH = riscv::PLEN - DCACHE_INDEX_WIDTH;
+  localparam int unsigned DCACHE_USER_LINE_WIDTH = (AXI_USER_WIDTH == 1) ? 4 : 128;  // in bit
+  localparam int unsigned DCACHE_USER_WIDTH = cva6_config_pkg::CVA6ConfigDataUserWidth;
+
+  localparam int unsigned MEM_TID_WIDTH = `L15_THREADID_WIDTH;
+`endif
+
+  // ---------------
+  // EX Stage
+  // ---------------
+
+  typedef enum logic [7:0] {  // basic ALU op
+    ADD,
+    SUB,
+    ADDW,
+    SUBW,
+    // logic operations
+    XORL,
+    ORL,
+    ANDL,
+    // shifts
+    SRA,
+    SRL,
+    SLL,
+    SRLW,
+    SLLW,
+    SRAW,
+    // comparisons
+    LTS,
+    LTU,
+    GES,
+    GEU,
+    EQ,
+    NE,
+    // jumps
+    JALR,
+    BRANCH,
+    // set lower than operations
+    SLTS,
+    SLTU,
+    // CSR functions
+    MRET,
+    SRET,
+    DRET,
+    ECALL,
+    WFI,
+    FENCE,
+    FENCE_I,
+    SFENCE_VMA,
+    HFENCE_VVMA,
+    HFENCE_GVMA,
+    CSR_WRITE,
+    CSR_READ,
+    CSR_SET,
+    CSR_CLEAR,
+    // LSU functions
+    LD,
+    SD,
+    LW,
+    LWU,
+    SW,
+    LH,
+    LHU,
+    SH,
+    LB,
+    SB,
+    LBU,
+    // Hypervisor Virtual-Machine Load and Store Instructions
+    HLV_B,
+    HLV_BU,
+    HLV_H,
+    HLV_HU,
+    HLVX_HU,
+    HLV_W,
+    HLVX_WU,
+    HSV_B,
+    HSV_H,
+    HSV_W,
+    HLV_WU,
+    HLV_D,
+    HSV_D,
+    // Atomic Memory Operations
+    AMO_LRW,
+    AMO_LRD,
+    AMO_SCW,
+    AMO_SCD,
+    AMO_SWAPW,
+    AMO_ADDW,
+    AMO_ANDW,
+    AMO_ORW,
+    AMO_XORW,
+    AMO_MAXW,
+    AMO_MAXWU,
+    AMO_MINW,
+    AMO_MINWU,
+    AMO_SWAPD,
+    AMO_ADDD,
+    AMO_ANDD,
+    AMO_ORD,
+    AMO_XORD,
+    AMO_MAXD,
+    AMO_MAXDU,
+    AMO_MIND,
+    AMO_MINDU,
+    // cache block operations (CBO)
+    CBO_CLEAN,
+    CBO_FLUSH,
+    CBO_INVAL,
+    CBO_NONE,
+    // Multiplications
+    MUL,
+    MULH,
+    MULHU,
+    MULHSU,
+    MULW,
+    // Divisions
+    DIV,
+    DIVU,
+    DIVW,
+    DIVUW,
+    REM,
+    REMU,
+    REMW,
+    REMUW,
+    // Floating-Point Load and Store Instructions
+    FLD,
+    FLW,
+    FLH,
+    FLB,
+    FSD,
+    FSW,
+    FSH,
+    FSB,
+    // Floating-Point Computational Instructions
+    FADD,
+    FSUB,
+    FMUL,
+    FDIV,
+    FMIN_MAX,
+    FSQRT,
+    FMADD,
+    FMSUB,
+    FNMSUB,
+    FNMADD,
+    // Floating-Point Conversion and Move Instructions
+    FCVT_F2I,
+    FCVT_I2F,
+    FCVT_F2F,
+    FSGNJ,
+    FMV_F2X,
+    FMV_X2F,
+    // Floating-Point Compare Instructions
+    FCMP,
+    // Floating-Point Classify Instruction
+    FCLASS,
+    // Vectorial Floating-Point Instructions that don't directly map onto the scalar ones
+    VFMIN,
+    VFMAX,
+    VFSGNJ,
+    VFSGNJN,
+    VFSGNJX,
+    VFEQ,
+    VFNE,
+    VFLT,
+    VFGE,
+    VFLE,
+    VFGT,
+    VFCPKAB_S,
+    VFCPKCD_S,
+    VFCPKAB_D,
+    VFCPKCD_D,
+    // Offload Instructions to be directed into cv_x_if
+    OFFLOAD,
+    // Or-Combine and REV8
+    ORCB,
+    REV8,
+    // Bitwise Rotation
+    ROL,
+    ROLW,
+    ROR,
+    RORI,
+    RORIW,
+    RORW,
+    // Sign and Zero Extend
+    SEXTB,
+    SEXTH,
+    ZEXTH,
+    // Count population
+    CPOP,
+    CPOPW,
+    // Count Leading/Training Zeros
+    CLZ,
+    CLZW,
+    CTZ,
+    CTZW,
+    // Carry less multiplication Op's
+    CLMUL,
+    CLMULH,
+    CLMULR,
+    // Single bit instructions Op's
+    BCLR,
+    BCLRI,
+    BEXT,
+    BEXTI,
+    BINV,
+    BINVI,
+    BSET,
+    BSETI,
+    // Integer minimum/maximum
+    MAX,
+    MAXU,
+    MIN,
+    MINU,
+    // Shift with Add Unsigned Word and Unsigned Word Op's (Bitmanip)
+    SH1ADDUW,
+    SH2ADDUW,
+    SH3ADDUW,
+    ADDUW,
+    SLLIUW,
+    // Shift with Add (Bitmanip)
+    SH1ADD,
+    SH2ADD,
+    SH3ADD,
+    // Bitmanip Logical with negate op (Bitmanip)
+    ANDN,
+    ORN,
+    XNOR,
+    // Accelerator operations
+    ACCEL_OP,
+    ACCEL_OP_FS1,
+    ACCEL_OP_FD,
+    ACCEL_OP_LOAD,
+    ACCEL_OP_STORE,
+    // Zicond instruction
+    CZERO_EQZ,
+    CZERO_NEZ,
+    // Pack instructions
+    PACK,
+    PACK_H,
+    PACK_W,
+    // Brev8 instruction
+    BREV8,
+    // Zip instructions
+    UNZIP,
+    ZIP,
+    // Xperm instructions
+    XPERM8,
+    XPERM4,
+    // AES Encryption instructions
+    AES32ESI,
+    AES32ESMI,
+    AES64ES,
+    AES64ESM,
+    // AES Decryption instructions
+    AES32DSI,
+    AES32DSMI,
+    AES64DS,
+    AES64DSM,
+    AES64IM,
+    // AES Key-Schedule instructions
+    AES64KS1I,
+    AES64KS2,
+    // Hashing instructions
+    SHA256SIG0,
+    SHA256SIG1,
+    SHA256SUM0,
+    SHA256SUM1,
+    SHA512SIG0H,
+    SHA512SIG0L,
+    SHA512SIG1H,
+    SHA512SIG1L,
+    SHA512SUM0R,
+    SHA512SUM1R,
+    SHA512SIG0,
+    SHA512SIG1,
+    SHA512SUM0,
+    SHA512SUM1
+  } fu_op;
+
+  typedef struct packed {
+    logic rs1_from_rd;
+    logic rs2_from_rd;
+  } alu_bypass_t;
+
+  function automatic logic op_is_branch(input fu_op op);
+    unique case (op) inside
+      EQ, NE, LTS, GES, LTU, GEU: return 1'b1;
+      default:                    return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // -------------------------------
+  // Extract Src/Dst FP Reg from Op
+  // -------------------------------
+  // function used in instr_trace svh
+  // is_rs1_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rs1_fpr(input fu_op op);
+    unique case (op) inside
+      [FMUL : FNMADD],  // Computational Operations (except ADD/SUB)
+      FCVT_F2I,  // Float-Int Casts
+      FCVT_F2F,  // Float-Float Casts
+      FSGNJ,  // Sign Injections
+      FMV_F2X,  // FPR-GPR Moves
+      FCMP,  // Comparisons
+      FCLASS,  // Classifications
+      [VFMIN : VFCPKCD_D],  // Additional Vectorial FP ops
+      ACCEL_OP_FS1:
+      return 1'b1;  // Accelerator instructions
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_rs2_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rs2_fpr(input fu_op op);
+    unique case (op) inside
+      [FSD : FSB],  // FP Stores
+      [FADD : FMIN_MAX],  // Computational Operations (no sqrt)
+      [FMADD : FNMADD],  // Fused Computational Operations
+      FCVT_F2F,  // Vectorial F2F Conversions require target
+      [FSGNJ : FMV_F2X],  // Sign Injections and moves mapped to SGNJ
+      FCMP,  // Comparisons
+      [VFMIN : VFCPKCD_D]:
+      return 1'b1;  // Additional Vectorial FP ops
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_imm_fpr function is kept to allow cva6 compilation with instr_trace feature
+  // ternary operations encode the rs3 address in the imm field, also add/sub
+  function automatic logic is_imm_fpr(input fu_op op);
+    unique case (op) inside
+      [FADD : FSUB],  // ADD/SUB need inputs as Operand B/C
+      [FMADD : FNMADD],  // Fused Computational Operations
+      [VFCPKAB_S : VFCPKCD_D]:
+      return 1'b1;  // Vectorial FP cast and pack ops
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  // function used in instr_trace svh
+  // is_rd_fpr function is kept to allow cva6 compilation with instr_trace feature
+  function automatic logic is_rd_fpr(input fu_op op);
+    unique case (op) inside
+      [FLD : FLB],  // FP Loads
+      [FADD : FNMADD],  // Computational Operations
+      FCVT_I2F,  // Int-Float Casts
+      FCVT_F2F,  // Float-Float Casts
+      FSGNJ,  // Sign Injections
+      FMV_X2F,  // GPR-FPR Moves
+      [VFMIN : VFSGNJX],  // Vectorial MIN/MAX and SGNJ
+      [VFCPKAB_S : VFCPKCD_D],  // Vectorial FP cast and pack ops
+      ACCEL_OP_FD:
+      return 1'b1;  // Accelerator instructions
+      default: return 1'b0;  // all other ops
+    endcase
+  endfunction
+
+  function automatic logic fd_changes_rd_state(input fu_op op);
+    unique case (op) inside
+      FSD, FSW, FSH, FSB,  // stores
+      FCVT_F2I,  // conversion to int
+      FMV_F2X,  // move as-is to int
+      FCLASS:  // classification (writes output to integer register)
+      return 1'b0;  // floating-point registers are only read
+      default: return 1'b1;  // other ops - floating-point registers are written as well
+    endcase
+  endfunction
+
+  function automatic logic is_amo(fu_op op);
+    case (op) inside
+      [AMO_LRW : AMO_MINDU]: begin
+        return 1'b1;
+      end
+      default: return 1'b0;
+    endcase
+  endfunction
+
+  // -------------------
+  // Performance counter
+  // -------------------
+  localparam int unsigned MHPMCounterNum = 6;
+
+  // --------------------
+  // Atomics
+  // --------------------
+  typedef enum logic [3:0] {
+    AMO_NONE = 4'b0000,
+    AMO_LR   = 4'b0001,
+    AMO_SC   = 4'b0010,
+    AMO_SWAP = 4'b0011,
+    AMO_ADD  = 4'b0100,
+    AMO_AND  = 4'b0101,
+    AMO_OR   = 4'b0110,
+    AMO_XOR  = 4'b0111,
+    AMO_MAX  = 4'b1000,
+    AMO_MAXU = 4'b1001,
+    AMO_MIN  = 4'b1010,
+    AMO_MINU = 4'b1011,
+    AMO_CAS1 = 4'b1100,  // unused, not part of riscv spec, but provided in OpenPiton
+    AMO_CAS2 = 4'b1101   // unused, not part of riscv spec, but provided in OpenPiton
+  } amo_t;
+
+  // Bits required for representation of physical address space as 4K pages
+  // (e.g. 27*4K == 39bit address space).
+  localparam PPN4K_WIDTH = 38;
+
+  typedef struct packed {
+    logic             valid;    // valid flag
+    logic             is_4M;    //
+    logic [20-1:0]    vpn;      //VPN (32bits) = 20bits + 12bits offset
+    logic [9-1:0]     asid;     //ASID length = 9 for Sv32 mmu
+    riscv::pte_sv32_t content;
+  } tlb_update_sv32_t;
+
+  typedef enum logic [1:0] {
+    FE_NONE,
+    FE_INSTR_ACCESS_FAULT,
+    FE_INSTR_PAGE_FAULT,
+    FE_INSTR_GUEST_PAGE_FAULT
+  } frontend_exception_t;
+
+  // AMO request going to cache. this request is unconditionally valid as soon
+  // as request goes high.
+  // Furthermore, those signals are kept stable until the response indicates
+  // completion by asserting ack.
+  typedef struct packed {
+    logic        req;        // this request is valid
+    amo_t        amo_op;     // atomic memory operation to perform
+    logic [1:0]  size;       // 2'b10 --> word operation, 2'b11 --> double word operation
+    logic [63:0] operand_a;  // address
+    logic [63:0] operand_b;  // data as layouted in the register
+  } amo_req_t;
+
+  // AMO response coming from cache.
+  typedef struct packed {
+    logic        ack;     // response is valid
+    logic [63:0] result;  // sign-extended, result
+  } amo_resp_t;
+
+  localparam RVFI = cva6_config_pkg::CVA6ConfigRvfiTrace;
+
+  // ----------------------
+  // Arithmetic Functions
+  // ----------------------
+  function automatic logic [63:0] sext32to64(logic [31:0] operand);
+    return {{32{operand[31]}}, operand[31:0]};
+  endfunction
+
+  // ----------------------
+  // LSU Functions
+  // ----------------------
+  // generate byte enable mask
+  function automatic logic [7:0] be_gen(logic [2:0] addr, logic [1:0] size);
+    case (size)
+      2'b11: begin
+        return 8'b1111_1111;
+      end
+      2'b10: begin
+        case (addr[2:0])
+          3'b000:  return 8'b0000_1111;
+          3'b001:  return 8'b0001_1110;
+          3'b010:  return 8'b0011_1100;
+          3'b011:  return 8'b0111_1000;
+          3'b100:  return 8'b1111_0000;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b01: begin
+        case (addr[2:0])
+          3'b000:  return 8'b0000_0011;
+          3'b001:  return 8'b0000_0110;
+          3'b010:  return 8'b0000_1100;
+          3'b011:  return 8'b0001_1000;
+          3'b100:  return 8'b0011_0000;
+          3'b101:  return 8'b0110_0000;
+          3'b110:  return 8'b1100_0000;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b00: begin
+        case (addr[2:0])
+          3'b000: return 8'b0000_0001;
+          3'b001: return 8'b0000_0010;
+          3'b010: return 8'b0000_0100;
+          3'b011: return 8'b0000_1000;
+          3'b100: return 8'b0001_0000;
+          3'b101: return 8'b0010_0000;
+          3'b110: return 8'b0100_0000;
+          3'b111: return 8'b1000_0000;
+        endcase
+      end
+    endcase
+    return 8'b0;
+  endfunction
+
+  function automatic logic [3:0] be_gen_32(logic [1:0] addr, logic [1:0] size);
+    case (size)
+      2'b10: begin
+        return 4'b1111;
+      end
+      2'b01: begin
+        case (addr[1:0])
+          2'b00:   return 4'b0011;
+          2'b01:   return 4'b0110;
+          2'b10:   return 4'b1100;
+          default: ;  // Do nothing
+        endcase
+      end
+      2'b00: begin
+        case (addr[1:0])
+          2'b00: return 4'b0001;
+          2'b01: return 4'b0010;
+          2'b10: return 4'b0100;
+          2'b11: return 4'b1000;
+        endcase
+      end
+      default: return 4'b0;
+    endcase
+    return 4'b0;
+  endfunction
+
+  // ----------------------
+  // Extract Bytes from Op
+  // ----------------------
+  function automatic logic [1:0] extract_transfer_size(fu_op op);
+    case (op)
+      LD, HLV_D, SD, HSV_D, FLD, FSD,
+            AMO_LRD,   AMO_SCD,
+            AMO_SWAPD, AMO_ADDD,
+            AMO_ANDD,  AMO_ORD,
+            AMO_XORD,  AMO_MAXD,
+            AMO_MAXDU, AMO_MIND,
+            AMO_MINDU: begin
+        return 2'b11;
+      end
+      LW, LWU, HLV_W, HLV_WU, HLVX_WU,
+            SW, HSV_W, FLW, FSW,
+            AMO_LRW,   AMO_SCW,
+            AMO_SWAPW, AMO_ADDW,
+            AMO_ANDW,  AMO_ORW,
+            AMO_XORW,  AMO_MAXW,
+            AMO_MAXWU, AMO_MINW,
+            AMO_MINWU: begin
+        return 2'b10;
+      end
+      LH, LHU, HLV_H, HLV_HU, HLVX_HU, SH, HSV_H, FLH, FSH: return 2'b01;
+      LB, LBU, HLV_B, HLV_BU, SB, HSV_B, FLB, FSB:          return 2'b00;
+      CBO_CLEAN, CBO_FLUSH, CBO_INVAL:                      return 2'b00;
+      default:                                              return 2'b11;
+    endcase
+  endfunction
+  // ----------------------
+  // MMU Functions
+  // ----------------------
+
+  // checks if final translation page size is 1G when H-extension is enabled
+  function automatic logic is_trans_1G(input logic s_st_enbl, input logic g_st_enbl,
+                                       input logic is_s_1G, input logic is_g_1G);
+    return (((is_s_1G && s_st_enbl) || !s_st_enbl) && ((is_g_1G && g_st_enbl) || !g_st_enbl));
+  endfunction : is_trans_1G
+
+  // checks if final translation page size is 2M when H-extension is enabled
+  function automatic logic is_trans_2M(input logic s_st_enbl, input logic g_st_enbl,
+                                       input logic is_s_1G, input logic is_s_2M,
+                                       input logic is_g_1G, input logic is_g_2M);
+    return  (s_st_enbl && g_st_enbl) ?
+                ((is_s_2M && (is_g_1G || is_g_2M)) || (is_g_2M && (is_s_1G || is_s_2M))) :
+                ((is_s_2M && s_st_enbl) || (is_g_2M && g_st_enbl));
+  endfunction : is_trans_2M
+
+  // computes the paddr based on the page size, ppn and offset
+  function automatic logic [40:0] make_gpaddr(input logic s_st_enbl, input logic is_1G,
+                                              input logic is_2M, input logic [63:0] vaddr,
+                                              input riscv::pte_t pte);
+    logic [40:0] gpaddr;
+    if (s_st_enbl) begin
+      gpaddr = {pte.ppn[28:0], vaddr[11:0]};
+      // Giga page
+      if (is_1G) gpaddr[29:12] = vaddr[29:12];
+      // Mega page
+      if (is_2M) gpaddr[20:12] = vaddr[20:12];
+    end else begin
+      gpaddr = vaddr[40:0];
+    end
+    return gpaddr;
+  endfunction : make_gpaddr
+
+  // computes the final gppn based on the guest physical address
+  function automatic logic [28:0] make_gppn(input logic s_st_enbl, input logic is_1G,
+                                            input logic is_2M, input logic [28:0] vpn,
+                                            input riscv::pte_t pte);
+    logic [28:0] gppn;
+    if (s_st_enbl) begin
+      gppn = pte.ppn[28:0];
+      if (is_2M) gppn[8:0] = vpn[8:0];
+      if (is_1G) gppn[17:0] = vpn[17:0];
+    end else begin
+      gppn = vpn;
+    end
+    return gppn;
+  endfunction : make_gppn
+
+  // ----------------------
+  // Helper functions
+  // ----------------------
+  // Avoid negative array slices when defining parametrized sizes
+  function automatic int unsigned avoid_neg(int n);
+    return (n < 0) ? 0 : n;
+  endfunction : avoid_neg
+
+endpackage

--- a/modules/cva6-cvfpu/build_config_pkg.sv
+++ b/modules/cva6-cvfpu/build_config_pkg.sv
@@ -1,0 +1,207 @@
+package build_config_pkg;
+
+  function automatic config_pkg::cva6_cfg_t build_config(config_pkg::cva6_user_cfg_t CVA6Cfg);
+    bit IS_XLEN32 = (CVA6Cfg.XLEN == 32) ? 1'b1 : 1'b0;
+    bit IS_XLEN64 = (CVA6Cfg.XLEN == 32) ? 1'b0 : 1'b1;
+    bit FpPresent = CVA6Cfg.RVF | CVA6Cfg.RVD | CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8;
+    bit NSX = CVA6Cfg.XF16 | CVA6Cfg.XF16ALT | CVA6Cfg.XF8 | CVA6Cfg.XFVec;  // Are non-standard extensions present?
+    int unsigned FLen = CVA6Cfg.RVD ? 64 :  // D ext.
+    CVA6Cfg.RVF ? 32 :  // F ext.
+    CVA6Cfg.XF16 ? 16 :  // Xf16 ext.
+    CVA6Cfg.XF16ALT ? 16 :  // Xf16alt ext.
+    CVA6Cfg.XF8 ? 8 :  // Xf8 ext.
+    1;  // Unused in case of no FP
+
+    // Transprecision floating-point extensions configuration
+    bit RVFVec     = CVA6Cfg.RVF     & CVA6Cfg.XFVec & FLen>32; // FP32 vectors available if vectors and larger fmt enabled
+    bit XF16Vec    = CVA6Cfg.XF16    & CVA6Cfg.XFVec & FLen>16; // FP16 vectors available if vectors and larger fmt enabled
+    bit XF16ALTVec = CVA6Cfg.XF16ALT & CVA6Cfg.XFVec & FLen>16; // FP16ALT vectors available if vectors and larger fmt enabled
+    bit XF8Vec     = CVA6Cfg.XF8     & CVA6Cfg.XFVec & FLen>8;  // FP8 vectors available if vectors and larger fmt enabled
+
+    bit EnableAccelerator = CVA6Cfg.RVV;  // Currently only used by V extension (Ara)
+    int unsigned NrWbPorts = (CVA6Cfg.CvxifEn || EnableAccelerator) ? 5 : 4;
+
+    int unsigned ICACHE_INDEX_WIDTH = $clog2(CVA6Cfg.IcacheByteSize / CVA6Cfg.IcacheSetAssoc);
+    int unsigned DCACHE_INDEX_WIDTH = $clog2(CVA6Cfg.DcacheByteSize / CVA6Cfg.DcacheSetAssoc);
+    int unsigned DCACHE_OFFSET_WIDTH = $clog2(CVA6Cfg.DcacheLineWidth / 8);
+
+    // MMU
+    int unsigned VpnLen = (CVA6Cfg.XLEN == 64) ? (CVA6Cfg.RVH ? 29 : 27) : 20;
+    int unsigned PtLevels = (CVA6Cfg.XLEN == 64) ? 3 : 2;
+
+    config_pkg::cva6_cfg_t cfg;
+
+    cfg.XLEN = CVA6Cfg.XLEN;
+    cfg.VLEN = CVA6Cfg.VLEN;
+    cfg.PLEN = (CVA6Cfg.XLEN == 32) ? 34 : 56;
+    cfg.GPLEN = (CVA6Cfg.XLEN == 32) ? 34 : 41;
+    cfg.IS_XLEN32 = IS_XLEN32;
+    cfg.IS_XLEN64 = IS_XLEN64;
+    cfg.XLEN_ALIGN_BYTES = $clog2(CVA6Cfg.XLEN / 8);
+    cfg.ASID_WIDTH = (CVA6Cfg.XLEN == 64) ? 16 : 1;
+    cfg.VMID_WIDTH = (CVA6Cfg.XLEN == 64) ? 14 : 1;
+
+    cfg.FpgaEn = CVA6Cfg.FpgaEn;
+    cfg.FpgaAlteraEn = CVA6Cfg.FpgaAlteraEn;
+    cfg.TechnoCut = CVA6Cfg.TechnoCut;
+
+    cfg.SuperscalarEn = CVA6Cfg.SuperscalarEn;
+    cfg.NrCommitPorts = CVA6Cfg.SuperscalarEn ? unsigned'(2) : CVA6Cfg.NrCommitPorts;
+    cfg.NrIssuePorts = unsigned'(CVA6Cfg.SuperscalarEn ? 2 : 1);
+    cfg.SpeculativeSb = CVA6Cfg.SuperscalarEn;
+
+    cfg.NrALUs = CVA6Cfg.SuperscalarEn ? unsigned'(2) : unsigned'(1);
+    cfg.ALUBypass = CVA6Cfg.SuperscalarEn ? bit'(CVA6Cfg.ALUBypass) : bit'(0);
+
+    cfg.NrLoadPipeRegs = CVA6Cfg.NrLoadPipeRegs;
+    cfg.NrStorePipeRegs = CVA6Cfg.NrStorePipeRegs;
+    cfg.AxiAddrWidth = CVA6Cfg.AxiAddrWidth;
+    cfg.AxiDataWidth = CVA6Cfg.AxiDataWidth;
+    cfg.AxiIdWidth = CVA6Cfg.AxiIdWidth;
+    cfg.AxiUserWidth = CVA6Cfg.AxiUserWidth;
+    cfg.MEM_TID_WIDTH = CVA6Cfg.MemTidWidth;
+    cfg.NrLoadBufEntries = CVA6Cfg.NrLoadBufEntries;
+    cfg.RVF = CVA6Cfg.RVF;
+    cfg.RVD = CVA6Cfg.RVD;
+    cfg.XF16 = CVA6Cfg.XF16;
+    cfg.XF16ALT = CVA6Cfg.XF16ALT;
+    cfg.XF8 = CVA6Cfg.XF8;
+    cfg.RVA = CVA6Cfg.RVA;
+    cfg.RVB = CVA6Cfg.RVB;
+    cfg.ZKN = CVA6Cfg.ZKN;
+    cfg.RVV = CVA6Cfg.RVV;
+    cfg.RVC = CVA6Cfg.RVC;
+    cfg.RVH = CVA6Cfg.RVH;
+    cfg.RVZCB = CVA6Cfg.RVZCB;
+    cfg.RVZCMT = CVA6Cfg.RVZCMT;
+    cfg.RVZCMP = CVA6Cfg.RVZCMP;
+    cfg.XFVec = CVA6Cfg.XFVec;
+    cfg.CvxifEn = CVA6Cfg.CvxifEn;
+    cfg.CoproType = CVA6Cfg.CoproType;
+    cfg.RVZiCond = CVA6Cfg.RVZiCond;
+    cfg.RVZiCbom = CVA6Cfg.RVZiCbom;
+    cfg.RVZicntr = CVA6Cfg.RVZicntr;
+    cfg.RVZihpm = CVA6Cfg.RVZihpm;
+    cfg.NR_SB_ENTRIES = CVA6Cfg.NrScoreboardEntries;
+    cfg.TRANS_ID_BITS = $clog2(CVA6Cfg.NrScoreboardEntries);
+
+    cfg.FpPresent = bit'(FpPresent);
+    cfg.NSX = bit'(NSX);
+    cfg.FLen = unsigned'(FLen);
+    cfg.RVFVec = bit'(RVFVec);
+    cfg.XF16Vec = bit'(XF16Vec);
+    cfg.XF16ALTVec = bit'(XF16ALTVec);
+    cfg.XF8Vec = bit'(XF8Vec);
+    // Can take 2 or 3 in single issue. 4 or 6 in dual issue.
+    cfg.NrRgprPorts = unsigned'(CVA6Cfg.SuperscalarEn ? 4 : 2);
+    // cfg.NrRgprPorts = unsigned'(CVA6Cfg.SuperscalarEn ? 6 : 3);
+    cfg.NrWbPorts = unsigned'(NrWbPorts);
+    cfg.EnableAccelerator = bit'(EnableAccelerator);
+    cfg.PerfCounterEn = CVA6Cfg.PerfCounterEn;
+    cfg.MmuPresent = CVA6Cfg.MmuPresent;
+    cfg.RVS = CVA6Cfg.RVS;
+    cfg.RVU = CVA6Cfg.RVU;
+    cfg.SoftwareInterruptEn = CVA6Cfg.SoftwareInterruptEn;
+
+    cfg.HaltAddress = CVA6Cfg.HaltAddress;
+    cfg.ExceptionAddress = CVA6Cfg.ExceptionAddress;
+    cfg.RASDepth = CVA6Cfg.RASDepth;
+    cfg.BTBEntries = CVA6Cfg.BTBEntries;
+    cfg.BPType = CVA6Cfg.BPType;
+    cfg.BHTEntries = CVA6Cfg.BHTEntries;
+    cfg.BHTHist = CVA6Cfg.BHTHist;
+    cfg.DmBaseAddress = CVA6Cfg.DmBaseAddress;
+    cfg.TvalEn = CVA6Cfg.TvalEn;
+    cfg.DirectVecOnly = CVA6Cfg.DirectVecOnly;
+    cfg.NrPMPEntries = CVA6Cfg.NrPMPEntries;
+    cfg.PMPCfgRstVal = CVA6Cfg.PMPCfgRstVal;
+    cfg.PMPAddrRstVal = CVA6Cfg.PMPAddrRstVal;
+    cfg.PMPEntryReadOnly = CVA6Cfg.PMPEntryReadOnly;
+    cfg.PMPNapotEn = CVA6Cfg.PMPNapotEn;
+    cfg.NOCType = CVA6Cfg.NOCType;
+    cfg.NrNonIdempotentRules = CVA6Cfg.NrNonIdempotentRules;
+    cfg.NonIdempotentAddrBase = CVA6Cfg.NonIdempotentAddrBase;
+    cfg.NonIdempotentLength = CVA6Cfg.NonIdempotentLength;
+    cfg.NrExecuteRegionRules = CVA6Cfg.NrExecuteRegionRules;
+    cfg.ExecuteRegionAddrBase = CVA6Cfg.ExecuteRegionAddrBase;
+    cfg.ExecuteRegionLength = CVA6Cfg.ExecuteRegionLength;
+    cfg.NrCachedRegionRules = CVA6Cfg.NrCachedRegionRules;
+    cfg.CachedRegionAddrBase = CVA6Cfg.CachedRegionAddrBase;
+    cfg.CachedRegionLength = CVA6Cfg.CachedRegionLength;
+    cfg.MaxOutstandingStores = CVA6Cfg.MaxOutstandingStores;
+    cfg.DebugEn = CVA6Cfg.DebugEn;
+    cfg.SDTRIG = CVA6Cfg.SDTRIG;
+    cfg.Mcontrol6 = CVA6Cfg.Mcontrol6;
+    cfg.Icount = CVA6Cfg.Icount;
+    cfg.Etrigger = CVA6Cfg.Etrigger;
+    cfg.Itrigger = CVA6Cfg.Itrigger;
+    cfg.NonIdemPotenceEn = (CVA6Cfg.NrNonIdempotentRules > 0) && (CVA6Cfg.NonIdempotentLength > 0);
+    cfg.AxiBurstWriteEn = CVA6Cfg.AxiBurstWriteEn;
+
+    cfg.ICACHE_SET_ASSOC = CVA6Cfg.IcacheSetAssoc;
+    cfg.ICACHE_SET_ASSOC_WIDTH = CVA6Cfg.IcacheSetAssoc > 1 ? $clog2(CVA6Cfg.IcacheSetAssoc) :
+        CVA6Cfg.IcacheSetAssoc;
+    cfg.ICACHE_INDEX_WIDTH = ICACHE_INDEX_WIDTH;
+    cfg.ICACHE_TAG_WIDTH = cfg.PLEN - ICACHE_INDEX_WIDTH;
+    cfg.ICACHE_LINE_WIDTH = CVA6Cfg.IcacheLineWidth;
+    cfg.ICACHE_USER_LINE_WIDTH = (CVA6Cfg.AxiUserWidth == 1) ? 4 : CVA6Cfg.IcacheLineWidth;
+    cfg.DCacheType = CVA6Cfg.DCacheType;
+    cfg.DcacheIdWidth = CVA6Cfg.DcacheIdWidth;
+    cfg.DCACHE_SET_ASSOC = CVA6Cfg.DcacheSetAssoc;
+    cfg.DCACHE_SET_ASSOC_WIDTH = CVA6Cfg.DcacheSetAssoc > 1 ? $clog2(CVA6Cfg.DcacheSetAssoc) :
+        CVA6Cfg.DcacheSetAssoc;
+    cfg.DCACHE_INDEX_WIDTH = DCACHE_INDEX_WIDTH;
+    cfg.DCACHE_TAG_WIDTH = cfg.PLEN - DCACHE_INDEX_WIDTH;
+    cfg.DCACHE_LINE_WIDTH = CVA6Cfg.DcacheLineWidth;
+    cfg.DCACHE_USER_LINE_WIDTH = (CVA6Cfg.AxiUserWidth == 1) ? 4 : CVA6Cfg.DcacheLineWidth;
+    cfg.DCACHE_USER_WIDTH = CVA6Cfg.AxiUserWidth;
+    cfg.DCACHE_OFFSET_WIDTH = DCACHE_OFFSET_WIDTH;
+    cfg.DCACHE_NUM_WORDS = 2 ** (DCACHE_INDEX_WIDTH - DCACHE_OFFSET_WIDTH);
+
+    cfg.DCACHE_MAX_TX = unsigned'(2 ** CVA6Cfg.MemTidWidth);
+
+    cfg.DcacheFlushOnFence = CVA6Cfg.DcacheFlushOnFence;
+    cfg.DcacheFlushOnFenceI = CVA6Cfg.DcacheFlushOnFenceI;
+    cfg.DcacheInvalidateOnFlush = CVA6Cfg.DcacheInvalidateOnFlush;
+
+    cfg.DATA_USER_EN = CVA6Cfg.DataUserEn;
+    cfg.WtDcacheWbufDepth = CVA6Cfg.WtDcacheWbufDepth;
+    cfg.FETCH_USER_WIDTH = CVA6Cfg.FetchUserWidth;
+    cfg.FETCH_USER_EN = CVA6Cfg.FetchUserEn;
+    cfg.AXI_USER_EN = CVA6Cfg.DataUserEn | CVA6Cfg.FetchUserEn;
+
+    cfg.FETCH_WIDTH = unsigned'(CVA6Cfg.SuperscalarEn ? 64 : 32);
+    cfg.FETCH_ALIGN_BITS = $clog2(cfg.FETCH_WIDTH / 8);
+    cfg.INSTR_PER_FETCH = cfg.FETCH_WIDTH / (CVA6Cfg.RVC ? 16 : 32);
+    cfg.LOG2_INSTR_PER_FETCH = cfg.INSTR_PER_FETCH > 1 ? $clog2(cfg.INSTR_PER_FETCH) : 1;
+
+    cfg.ModeW = (CVA6Cfg.XLEN == 32) ? 1 : 4;
+    cfg.ASIDW = (CVA6Cfg.XLEN == 32) ? 9 : 16;
+    cfg.VMIDW = (CVA6Cfg.XLEN == 32) ? 7 : 14;
+    cfg.PPNW = (CVA6Cfg.XLEN == 32) ? 22 : 44;
+    cfg.GPPNW = (CVA6Cfg.XLEN == 32) ? 22 : 29;
+    cfg.MODE_SV = (CVA6Cfg.XLEN == 32) ? config_pkg::ModeSv32 : config_pkg::ModeSv39;
+    cfg.SV = (cfg.MODE_SV == config_pkg::ModeSv32) ? 32 : 39;
+    cfg.SVX = (cfg.MODE_SV == config_pkg::ModeSv32) ? 34 : 41;
+    cfg.InstrTlbEntries = CVA6Cfg.InstrTlbEntries;
+    cfg.DataTlbEntries = CVA6Cfg.DataTlbEntries;
+    cfg.UseSharedTlb = CVA6Cfg.UseSharedTlb;
+    cfg.SvnapotEn = CVA6Cfg.SvnapotEn;
+    cfg.SharedTlbDepth = CVA6Cfg.SharedTlbDepth;
+    cfg.VpnLen = VpnLen;
+    cfg.PtLevels = PtLevels;
+
+    cfg.X_NUM_RS = cfg.NrRgprPorts / cfg.NrIssuePorts;
+    cfg.X_ID_WIDTH = cfg.TRANS_ID_BITS;
+    cfg.X_RFR_WIDTH = cfg.XLEN;
+    cfg.X_RFW_WIDTH = cfg.XLEN;
+    cfg.X_NUM_HARTS = 1;
+    cfg.X_HARTID_WIDTH = cfg.XLEN;
+    cfg.X_DUALREAD = 0;
+    cfg.X_DUALWRITE = 0;
+    cfg.X_ISSUE_REGISTER_SPLIT = 0;
+
+    return cfg;
+  endfunction
+
+endpackage

--- a/modules/cva6-cvfpu/config_pkg.sv
+++ b/modules/cva6-cvfpu/config_pkg.sv
@@ -1,0 +1,504 @@
+// Copyright 2023 Thales DIS France SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+package config_pkg;
+
+  // ---------------
+  // Global Config
+  // ---------------
+  localparam int unsigned ILEN = 32;
+  localparam int unsigned NRET = 1;
+
+  /// The NoC type is a top-level parameter, hence we need a bit more
+  /// information on what protocol those type parameters are supporting.
+  /// Currently two values are supported"
+  typedef enum {
+    /// The "classic" AXI4 protocol.
+    NOC_TYPE_AXI4_ATOP,
+    /// In the OpenPiton setting the WT cache is connected to the L15.
+    NOC_TYPE_L15_BIG_ENDIAN,
+    NOC_TYPE_L15_LITTLE_ENDIAN
+  } noc_type_e;
+
+  /// Cache type parameter
+  typedef enum logic [2:0] {
+    WB = 0,
+    WT = 1,
+    HPDCACHE_WT = 2,
+    HPDCACHE_WB = 3,
+    HPDCACHE_WT_WB = 4
+  } cache_type_t;
+
+  /// Branch predictor parameter
+  typedef enum logic {
+    BHT = 0,  // Bimodal predictor
+    PH_BHT = 1  // Private History Bimodal predictor
+  } bp_type_t;
+
+  /// Data and Address length
+  typedef enum logic [3:0] {
+    ModeOff  = 0,
+    ModeSv32 = 1,
+    ModeSv39 = 8,
+    ModeSv48 = 9,
+    ModeSv57 = 10,
+    ModeSv64 = 11
+  } vm_mode_t;
+
+  /// Coprocessor type parameter
+  typedef enum {
+    COPRO_NONE,
+    COPRO_EXAMPLE
+  } copro_type_t;
+
+  localparam NrMaxRules = 16;
+
+  typedef struct packed {
+    // General Purpose Register Size (in bits)
+    int unsigned                 XLEN;
+    // Virtual address Size (in bits)
+    int unsigned                 VLEN;
+    // Atomic RISC-V extension
+    bit                          RVA;
+    // Bit manipulation RISC-V extension
+    bit                          RVB;
+    // Scalar Cryptography RISC-V extension
+    bit                          ZKN;
+    // Vector RISC-V extension
+    bit                          RVV;
+    // Compress RISC-V extension
+    bit                          RVC;
+    // Hypervisor RISC-V extension
+    bit                          RVH;
+    // Zcb RISC-V extension
+    bit                          RVZCB;
+    // Zcmp RISC-V extension
+    bit                          RVZCMP;
+    // Zcmt RISC-V extension
+    bit                          RVZCMT;
+    // Zicond RISC-V extension
+    bit                          RVZiCond;
+    // Zicbom RISC-V extension (cache management / CBO)
+    bit                          RVZiCbom;
+    // Zicntr RISC-V extension
+    bit                          RVZicntr;
+    // Zihpm RISC-V extension
+    bit                          RVZihpm;
+    // Floating Point
+    bit                          RVF;
+    // Floating Point
+    bit                          RVD;
+    // Non standard 16bits Floating Point extension
+    bit                          XF16;
+    // Non standard 16bits Floating Point Alt extension
+    bit                          XF16ALT;
+    // Non standard 8bits Floating Point extension
+    bit                          XF8;
+    // Non standard Vector Floating Point extension
+    bit                          XFVec;
+    // Perf counters
+    bit                          PerfCounterEn;
+    // MMU
+    bit                          MmuPresent;
+    // Supervisor mode
+    bit                          RVS;
+    // User mode
+    bit                          RVU;
+    // Software interrupts are enabled
+    bit                          SoftwareInterruptEn;
+    // Debug support
+    bit                          DebugEn;
+    // Base address of the debug module
+    logic [63:0]                 DmBaseAddress;
+    // Address to jump when halt request
+    logic [63:0]                 HaltAddress;
+    // Address to jump when exception
+    logic [63:0]                 ExceptionAddress;
+    // Trigger Module Sdtrig Extension
+    bit                          SDTRIG;
+    bit                          Mcontrol6;
+    bit                          Icount;
+    bit                          Etrigger;
+    bit                          Itrigger;
+    // Tval Support Enable
+    bit                          TvalEn;
+    // MTVEC CSR supports only direct mode
+    bit                          DirectVecOnly;
+    // PMP entries number
+    int unsigned                 NrPMPEntries;
+    // PMP CSR configuration reset values
+    logic [63:0][63:0]           PMPCfgRstVal;
+    // PMP CSR address reset values
+    logic [63:0][63:0]           PMPAddrRstVal;
+    // PMP CSR read-only bits
+    bit [63:0]                   PMPEntryReadOnly;
+    // PMP NA4 and NAPOT mode enable
+    bit                          PMPNapotEn;
+    // PMA non idempotent rules number
+    int unsigned                 NrNonIdempotentRules;
+    // PMA NonIdempotent region base address
+    logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
+    // PMA NonIdempotent region length
+    logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
+    // PMA regions with execute rules number
+    int unsigned                 NrExecuteRegionRules;
+    // PMA Execute region base address
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
+    // PMA Execute region address base
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
+    // PMA regions with cache rules number
+    int unsigned                 NrCachedRegionRules;
+    // PMA cache region base address
+    logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
+    // PMA cache region rules
+    logic [NrMaxRules-1:0][63:0] CachedRegionLength;
+    // CV-X-IF coprocessor interface enable
+    bit                          CvxifEn;
+    // Coprocessor type
+    copro_type_t                 CoproType;
+    // NOC bus type
+    noc_type_e                   NOCType;
+    // AXI address width
+    int unsigned                 AxiAddrWidth;
+    // AXI data width
+    int unsigned                 AxiDataWidth;
+    // AXI ID width
+    int unsigned                 AxiIdWidth;
+    // AXI User width
+    int unsigned                 AxiUserWidth;
+    // AXI burst in write
+    bit                          AxiBurstWriteEn;
+    // TODO
+    int unsigned                 MemTidWidth;
+    // Instruction cache size (in bytes)
+    int unsigned                 IcacheByteSize;
+    // Instruction cache associativity (number of ways)
+    int unsigned                 IcacheSetAssoc;
+    // Instruction cache line width
+    int unsigned                 IcacheLineWidth;
+    // Cache Type
+    cache_type_t                 DCacheType;
+    // Data cache ID
+    int unsigned                 DcacheIdWidth;
+    // Data cache size (in bytes)
+    int unsigned                 DcacheByteSize;
+    // Data cache associativity (number of ways)
+    int unsigned                 DcacheSetAssoc;
+    // Data cache line width
+    int unsigned                 DcacheLineWidth;
+    // three configurations for cache coherency after flush:
+    // DcacheFlushOnFence causes dcache flush for every fence instruction
+    // DcacheFlushOnFenceI causes dcache flush for every fence.I instruction
+    // DcacheInvalidateOnFlush causes dcache to also be invalidated when flushed
+    // tradeoff between coherence and efficiency, depending on remaining configuration:
+
+    // DcacheFlushOnFenceI is required for write-back caches - otherwise, 
+    // no way to reliably write instruction memory with store instructions, 
+    // as data and instruction cache are currently not coherent
+    // DcacheFlushOnFence is required for write-back caches to ensure coherency
+    // with other harts or DMA devices --> a fence forces all stores to commit to memory
+    // DcacheInvalidateOnFlush causes all dcache entries to become invalid, forcing the CPU
+    // to fetch data from memory after each fence --> make writes from other harts or DMAs
+    // visible to the CPU
+    // thus, DcacheFlushOnFence and DcacheInvalidateOnFlush can ensure DMA coherency at high performance cost
+    // using RVZiCbom can achieve the same effect at significantly lower performance cost
+    // hence, on uniprocessor or not cache-coherent multiprocessor SoCs, one might want to disable both and use
+    // explicit CBO operations for better overall performance
+    bit          DcacheFlushOnFence;
+    bit          DcacheFlushOnFenceI;
+    bit          DcacheInvalidateOnFlush;
+    // User field on data bus enable
+    int unsigned DataUserEn;
+    // Write-through data cache write buffer depth
+    int unsigned WtDcacheWbufDepth;
+    // User field on fetch bus enable
+    int unsigned FetchUserEn;
+    // Width of fetch user field
+    int unsigned FetchUserWidth;
+    // Is FPGA optimization of CV32A6 for Xilinx and Altera
+    bit          FpgaEn;
+    // Is FPGA optimization for Altera FPGA
+    bit          FpgaAlteraEn;
+    // Is Techno Cut instantiated
+    bit          TechnoCut;
+    // Enable superscalar* with 2 issue ports and 2 commit ports.
+    bit          SuperscalarEn;
+    // Enable ALU-ALU bypass (superscalar mode only)
+    bit          ALUBypass;
+    // Number of commit ports. Forced to 2 if SuperscalarEn.
+    int unsigned NrCommitPorts;
+    // Load cycle latency number
+    int unsigned NrLoadPipeRegs;
+    // Store cycle latency number
+    int unsigned NrStorePipeRegs;
+    // Scoreboard length
+    int unsigned NrScoreboardEntries;
+    // Load buffer entry buffer
+    int unsigned NrLoadBufEntries;
+    // Maximum number of outstanding stores
+    int unsigned MaxOutstandingStores;
+    // Return address stack depth
+    int unsigned RASDepth;
+    // Branch target buffer entries
+    int unsigned BTBEntries;
+    // Branch predictor type
+    bp_type_t    BPType;
+    // Branch history entries
+    int unsigned BHTEntries;
+    // Branch history bits
+    int unsigned BHTHist;
+    // MMU instruction TLB entries
+    int unsigned InstrTlbEntries;
+    // MMU data TLB entries
+    int unsigned DataTlbEntries;
+    // MMU option to use shared TLB
+    bit unsigned UseSharedTlb;
+    // MMU depth of shared TLB
+    int unsigned SharedTlbDepth;
+    // Option to enable Svnapot extension
+    bit          SvnapotEn;
+  } cva6_user_cfg_t;
+
+  typedef struct packed {
+    int unsigned XLEN;
+    int unsigned VLEN;
+    int unsigned PLEN;
+    int unsigned GPLEN;
+    bit IS_XLEN32;
+    bit IS_XLEN64;
+    int unsigned XLEN_ALIGN_BYTES;
+    int unsigned ASID_WIDTH;
+    int unsigned VMID_WIDTH;
+
+    bit FpgaEn;
+    bit FpgaAlteraEn;
+    bit TechnoCut;
+
+    bit          SuperscalarEn;
+    int unsigned NrCommitPorts;
+    int unsigned NrIssuePorts;
+    bit          SpeculativeSb;
+
+    int unsigned NrALUs;
+    bit          ALUBypass;
+
+    int unsigned NrLoadPipeRegs;
+    int unsigned NrStorePipeRegs;
+    /// AXI parameters.
+    int unsigned AxiAddrWidth;
+    int unsigned AxiDataWidth;
+    int unsigned AxiIdWidth;
+    int unsigned AxiUserWidth;
+    int unsigned MEM_TID_WIDTH;
+    int unsigned NrLoadBufEntries;
+    bit          RVF;
+    bit          RVD;
+    bit          XF16;
+    bit          XF16ALT;
+    bit          XF8;
+    bit          RVA;
+    bit          RVB;
+    bit          ZKN;
+    bit          RVV;
+    bit          RVC;
+    bit          RVH;
+    bit          RVZCB;
+    bit          RVZCMP;
+    bit          RVZCMT;
+    bit          XFVec;
+    bit          CvxifEn;
+    copro_type_t CoproType;
+    bit          RVZiCond;
+    bit          RVZiCbom;
+    bit          RVZicntr;
+    bit          RVZihpm;
+
+    int unsigned NR_SB_ENTRIES;
+    int unsigned TRANS_ID_BITS;
+
+    bit          FpPresent;
+    bit          NSX;
+    int unsigned FLen;
+    bit          RVFVec;
+    bit          XF16Vec;
+    bit          XF16ALTVec;
+    bit          XF8Vec;
+    int unsigned NrRgprPorts;
+    int unsigned NrWbPorts;
+    bit          EnableAccelerator;
+    bit          PerfCounterEn;
+    bit          MmuPresent;
+    bit          RVS;                  //Supervisor mode
+    bit          RVU;                  //User mode
+    bit          SoftwareInterruptEn;
+
+    logic [63:0] HaltAddress;
+    logic [63:0] ExceptionAddress;
+    int unsigned RASDepth;
+    int unsigned BTBEntries;
+    bp_type_t    BPType;
+    int unsigned BHTEntries;
+    int unsigned BHTHist;
+    int unsigned InstrTlbEntries;
+    int unsigned DataTlbEntries;
+    bit unsigned UseSharedTlb;
+    bit SvnapotEn;
+    int unsigned SharedTlbDepth;
+    int unsigned VpnLen;
+    int unsigned PtLevels;
+
+    logic [63:0]                 DmBaseAddress;
+    bit                          TvalEn;
+    bit                          DirectVecOnly;
+    int unsigned                 NrPMPEntries;
+    logic [63:0][63:0]           PMPCfgRstVal;
+    logic [63:0][63:0]           PMPAddrRstVal;
+    bit [63:0]                   PMPEntryReadOnly;
+    bit                          PMPNapotEn;
+    noc_type_e                   NOCType;
+    int unsigned                 NrNonIdempotentRules;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentAddrBase;
+    logic [NrMaxRules-1:0][63:0] NonIdempotentLength;
+    int unsigned                 NrExecuteRegionRules;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] ExecuteRegionLength;
+    int unsigned                 NrCachedRegionRules;
+    logic [NrMaxRules-1:0][63:0] CachedRegionAddrBase;
+    logic [NrMaxRules-1:0][63:0] CachedRegionLength;
+    int unsigned                 MaxOutstandingStores;
+    bit                          DebugEn;
+    bit                          SDTRIG;
+    bit                          Mcontrol6;
+    bit                          Icount;
+    bit                          Etrigger;
+    bit                          Itrigger;
+    bit                          NonIdemPotenceEn;       // Currently only used by V extension (Ara)
+    bit                          AxiBurstWriteEn;
+
+    int unsigned ICACHE_SET_ASSOC;
+    int unsigned ICACHE_SET_ASSOC_WIDTH;
+    int unsigned ICACHE_INDEX_WIDTH;
+    int unsigned ICACHE_TAG_WIDTH;
+    int unsigned ICACHE_LINE_WIDTH;
+    int unsigned ICACHE_USER_LINE_WIDTH;
+    cache_type_t DCacheType;
+    int unsigned DcacheIdWidth;
+    int unsigned DCACHE_SET_ASSOC;
+    int unsigned DCACHE_SET_ASSOC_WIDTH;
+    int unsigned DCACHE_INDEX_WIDTH;
+    int unsigned DCACHE_TAG_WIDTH;
+    int unsigned DCACHE_LINE_WIDTH;
+    int unsigned DCACHE_USER_LINE_WIDTH;
+    int unsigned DCACHE_USER_WIDTH;
+    int unsigned DCACHE_OFFSET_WIDTH;
+    int unsigned DCACHE_NUM_WORDS;
+
+    int unsigned DCACHE_MAX_TX;
+
+    bit DcacheFlushOnFence;
+    bit DcacheFlushOnFenceI;
+    bit DcacheInvalidateOnFlush;
+
+    int unsigned DATA_USER_EN;
+    int unsigned WtDcacheWbufDepth;
+    int unsigned FETCH_USER_WIDTH;
+    int unsigned FETCH_USER_EN;
+    bit          AXI_USER_EN;
+
+    int unsigned FETCH_WIDTH;
+    int unsigned FETCH_ALIGN_BITS;
+    int unsigned INSTR_PER_FETCH;
+    int unsigned LOG2_INSTR_PER_FETCH;
+
+    int unsigned ModeW;
+    int unsigned ASIDW;
+    int unsigned VMIDW;
+    int unsigned PPNW;
+    int unsigned GPPNW;
+    vm_mode_t MODE_SV;
+    int unsigned SV;
+    int unsigned SVX;
+
+    int unsigned X_NUM_RS;
+    int unsigned X_ID_WIDTH;
+    int unsigned X_RFR_WIDTH;
+    int unsigned X_RFW_WIDTH;
+    int unsigned X_NUM_HARTS;
+    int unsigned X_HARTID_WIDTH;
+    int unsigned X_DUALREAD;
+    int unsigned X_DUALWRITE;
+    int unsigned X_ISSUE_REGISTER_SPLIT;
+
+  } cva6_cfg_t;
+
+  /// Empty configuration to sanity check proper parameter passing. Whenever
+  /// you develop a module that resides within the core, assign this constant.
+  localparam cva6_cfg_t cva6_cfg_empty = cva6_cfg_t'(0);
+
+  /// Utility function being called to check parameters. Not all values make
+  /// sense for all parameters, here is the place to sanity check them.
+  function automatic void check_cfg(cva6_cfg_t Cfg);
+    // pragma translate_off
+    assert (Cfg.RASDepth > 0);
+    assert (Cfg.BTBEntries == 0 || (2 ** $clog2(Cfg.BTBEntries) == Cfg.BTBEntries));
+    assert (Cfg.BHTEntries == 0 || (2 ** $clog2(Cfg.BHTEntries) == Cfg.BHTEntries));
+    assert (Cfg.NrNonIdempotentRules <= NrMaxRules);
+    assert (Cfg.NrExecuteRegionRules <= NrMaxRules);
+    assert (Cfg.NrCachedRegionRules <= NrMaxRules);
+    assert (Cfg.NrPMPEntries <= 64);
+    assert (Cfg.FETCH_WIDTH == 32 || Cfg.FETCH_WIDTH == 64)
+    else $fatal(1, "[frontend] fetch width != not supported");
+    // Support for disabling MIP.MSIP and MIE.MSIE in Hypervisor and Supervisor mode is not supported
+    // Software Interrupt can be disabled when there is only M machine mode in CVA6.
+    assert (!(Cfg.RVS && !Cfg.SoftwareInterruptEn));
+    assert (!(Cfg.RVH && !Cfg.SoftwareInterruptEn));
+    assert (!(Cfg.RVZCMT && ~Cfg.MmuPresent));
+    // pragma translate_on
+  endfunction
+
+  function automatic logic range_check(logic [63:0] base, logic [63:0] len, logic [63:0] address);
+    // if len is a power of two, and base is properly aligned, this check could be simplified
+    // Extend base by one bit to prevent an overflow.
+    return (address >= base) && (({1'b0, address}) < (65'(base) + len));
+  endfunction : range_check
+
+
+  function automatic logic is_inside_nonidempotent_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    logic [NrMaxRules-1:0] pass;
+    pass = '0;
+    for (int unsigned k = 0; k < Cfg.NrNonIdempotentRules; k++) begin
+      pass[k] = range_check(Cfg.NonIdempotentAddrBase[k], Cfg.NonIdempotentLength[k], address);
+    end
+    return |pass;
+  endfunction : is_inside_nonidempotent_regions
+
+  function automatic logic is_inside_execute_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    // if we don't specify any region we assume everything is accessible
+    logic [NrMaxRules-1:0] pass;
+    if (Cfg.NrExecuteRegionRules != 0) begin
+      pass = '0;
+      for (int unsigned k = 0; k < Cfg.NrExecuteRegionRules; k++) begin
+        pass[k] = range_check(Cfg.ExecuteRegionAddrBase[k], Cfg.ExecuteRegionLength[k], address);
+      end
+      return |pass;
+    end else begin
+      return 1;
+    end
+  endfunction : is_inside_execute_regions
+
+  function automatic logic is_inside_cacheable_regions(cva6_cfg_t Cfg, logic [63:0] address);
+    automatic logic [NrMaxRules-1:0] pass;
+    pass = '0;
+    for (int unsigned k = 0; k < Cfg.NrCachedRegionRules; k++) begin
+      pass[k] = range_check(Cfg.CachedRegionAddrBase[k], Cfg.CachedRegionLength[k], address);
+    end
+    return |pass;
+  endfunction : is_inside_cacheable_regions
+
+endpackage

--- a/modules/cva6-cvfpu/cv64a60ax_config_pkg_cvfpu-uvm.sv
+++ b/modules/cva6-cvfpu/cv64a60ax_config_pkg_cvfpu-uvm.sv
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2025 CEA*
+ *  *Commissariat a l'Energie Atomique et aux Energies Alternatives (CEA)
+ *
+ *  SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+ *
+ *  Licensed under the Solderpad Hardware License v 2.1 (the “License”); you
+ *  may not use this file except in compliance with the License, or, at your
+ *  option, the Apache License version 2.0. You may obtain a copy of the
+ *  License at
+ *
+ *  https://solderpad.org/licenses/SHL-2.1/
+ *
+ *  Unless required by applicable law or agreed to in writing, any work
+ *  distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+
+package cva6_config_pkg;
+
+  localparam CVA6ConfigXlen = 64;
+  localparam CVA6ConfigRvfiTrace = 1;
+
+  localparam CVA6ConfigAxiIdWidth = 4;
+  localparam CVA6ConfigAxiAddrWidth = 39;
+  localparam CVA6ConfigAxiDataWidth = 128;
+  localparam CVA6ConfigDataUserWidth = 12;
+
+  localparam config_pkg::cva6_user_cfg_t cva6_cfg = '{
+      XLEN: unsigned'(CVA6ConfigXlen),
+      VLEN: unsigned'(64),
+      FpgaEn: bit'(0),  // for Xilinx and Altera
+      FpgaAlteraEn: bit'(0),  // for Altera (only)
+      TechnoCut: bit'(0),
+      SuperscalarEn: bit'(0),
+      ALUBypass: bit'(0),
+      NrCommitPorts: unsigned'(2),
+      AxiAddrWidth: unsigned'(CVA6ConfigAxiAddrWidth),
+      AxiDataWidth: unsigned'(CVA6ConfigAxiDataWidth),
+      AxiIdWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      AxiUserWidth: unsigned'(CVA6ConfigDataUserWidth),
+      MemTidWidth: unsigned'(CVA6ConfigAxiIdWidth),
+      NrLoadBufEntries: unsigned'(8),
+      RVF: bit'(1),
+      RVD: bit'(1),
+      XF16: bit'(1),
+      XF16ALT: bit'(0),
+      XF8: bit'(0),
+      RVA: bit'(1),
+      RVB: bit'(1),
+      ZKN: bit'(0),
+      RVV: bit'(1),
+      RVC: bit'(1),
+      RVH: bit'(0),
+      RVZCMT: bit'(0),
+      RVZCB: bit'(1),
+      RVZCMP: bit'(0),
+      XFVec: bit'(0),
+      CvxifEn: bit'(1),
+      CoproType: config_pkg::COPRO_EXAMPLE,
+      RVZiCond: bit'(1),
+      RVZicntr: bit'(1),
+      RVZiCbom: bit'(1),
+      RVZihpm: bit'(1),
+      NrScoreboardEntries: unsigned'(8),
+      PerfCounterEn: bit'(1),
+      MmuPresent: bit'(1),
+      RVS: bit'(1),
+      RVU: bit'(1),
+      SoftwareInterruptEn: bit'(1),
+      HaltAddress: 64'h800,
+      ExceptionAddress: 64'h808,
+      RASDepth: unsigned'(2),
+      BTBEntries: unsigned'(16),
+      BPType: config_pkg::BHT,
+      BHTEntries: unsigned'(64),
+      BHTHist: unsigned'(3),
+      DmBaseAddress: 64'h300_0000,
+      TvalEn: bit'(1),
+      DirectVecOnly: bit'(0),
+      NrPMPEntries: unsigned'(8),
+      PMPCfgRstVal: {64{64'h0}},
+      PMPAddrRstVal: {64{64'h0}},
+      PMPEntryReadOnly: 64'd0,
+      PMPNapotEn: bit'(1),
+      NOCType: config_pkg::NOC_TYPE_AXI4_ATOP,
+      NrNonIdempotentRules: unsigned'(2),
+      NonIdempotentAddrBase: 1024'({64'b0, 64'b0}),
+      NonIdempotentLength: 1024'({64'b0, 64'b0}),
+      NrExecuteRegionRules: unsigned'(6),
+      ExecuteRegionAddrBase:
+      1024'(
+      {64'h1_0000_0000, 64'h8000_0000, 64'h300_0000, 64'h0, 64'h2000_0000, 64'h8_0000_0000}
+      ),
+      ExecuteRegionLength:
+      1024'(
+      {64'h2_0000_0000, 64'h1_0000, 64'h1000, 64'h1_0000, 64'h2000_0000, 64'h7_FFFF_FFFF}
+      ),
+      NrCachedRegionRules: unsigned'(2),
+      CachedRegionAddrBase: 1024'({64'h1_0000_0000, 64'h8000_0000}),
+      CachedRegionLength: 1024'({64'h2_0000_0000, 64'h1_0000}),
+      MaxOutstandingStores: unsigned'(7),
+      DebugEn: bit'(1),
+      SDTRIG: bit'(0),
+      Mcontrol6: bit'(0),
+      Icount: bit'(0),
+      Etrigger: bit'(0),
+      Itrigger: bit'(0),
+      AxiBurstWriteEn: bit'(1),
+      IcacheByteSize: unsigned'(32768),
+      IcacheSetAssoc: unsigned'(8),
+      IcacheLineWidth: unsigned'(512),
+      DCacheType: config_pkg::HPDCACHE_WT,
+      DcacheByteSize: unsigned'(32768),
+      DcacheSetAssoc: unsigned'(8),
+      DcacheLineWidth: unsigned'(512),
+      DcacheFlushOnFence: bit'(0),
+      DcacheFlushOnFenceI: bit'(0),
+      DcacheInvalidateOnFlush: bit'(0),
+      DataUserEn: unsigned'(0),
+      WtDcacheWbufDepth: int'(8),
+      FetchUserWidth: unsigned'(32),
+      FetchUserEn: unsigned'(0),
+      InstrTlbEntries: int'(16),
+      DataTlbEntries: int'(16),
+      UseSharedTlb: bit'(0),
+      SvnapotEn: bit'(0),
+      SharedTlbDepth: int'(64),
+      NrLoadPipeRegs: int'(0),
+      NrStorePipeRegs: int'(0),
+      DcacheIdWidth: int'(3)
+  };
+
+endpackage

--- a/modules/cva6-cvfpu/fpu_wrap.sv
+++ b/modules/cva6-cvfpu/fpu_wrap.sv
@@ -1,0 +1,576 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Stefan Mach, ETH Zurich
+// Date: 12.04.2018
+// Description: Wrapper for the floating-point unit
+
+
+module fpu_wrap
+  import ariane_pkg::*;
+#(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type exception_t = logic,
+    parameter type fu_data_t = logic
+) (
+    input  logic     clk_i,
+    input  logic     rst_ni,
+    input  logic     flush_i,
+    input  logic     fpu_valid_i,
+    output logic     fpu_ready_o,
+    input  fu_data_t fu_data_i,
+
+    input  logic       [                      1:0] fpu_fmt_i,
+    input  logic       [                      2:0] fpu_rm_i,
+    input  logic       [                      2:0] fpu_frm_i,
+    input  logic       [                      6:0] fpu_prec_i,
+    output logic       [CVA6Cfg.TRANS_ID_BITS-1:0] fpu_trans_id_o,
+    output logic       [         CVA6Cfg.FLen-1:0] result_o,
+    output logic                                   fpu_valid_o,
+    output exception_t                             fpu_exception_o,
+    output logic                                   fpu_early_valid_o
+);
+
+  // this is a workaround
+  // otherwise compilation might issue an error if FLEN=0
+  enum logic {
+    READY,
+    STALL
+  }
+      state_q, state_d;
+  if (CVA6Cfg.FpPresent) begin : fpu_gen
+    logic [CVA6Cfg.FLen-1:0] operand_a_i;
+    logic [CVA6Cfg.FLen-1:0] operand_b_i;
+    logic [CVA6Cfg.FLen-1:0] operand_c_i;
+    assign operand_a_i = fu_data_i.operand_a[CVA6Cfg.FLen-1:0];
+    assign operand_b_i = fu_data_i.operand_b[CVA6Cfg.FLen-1:0];
+    assign operand_c_i = fu_data_i.imm[CVA6Cfg.FLen-1:0];
+
+    //-----------------------------------
+    // FPnew config from FPnew package
+    //-----------------------------------
+    localparam OPBITS = fpnew_pkg::OP_BITS;
+    localparam FMTBITS = $clog2(fpnew_pkg::NUM_FP_FORMATS);
+    localparam IFMTBITS = $clog2(fpnew_pkg::NUM_INT_FORMATS);
+
+    // Features (enabled formats, vectors etc.)
+    localparam fpnew_pkg::fpu_features_t FPU_FEATURES = '{
+        Width: unsigned'(CVA6Cfg.FLen),  // parameterized using CVA6Cfg.FLen
+        EnableVectors: CVA6Cfg.XFVec,
+        EnableNanBox: 1'b1,
+        FpFmtMask: {CVA6Cfg.RVF, CVA6Cfg.RVD, CVA6Cfg.XF16, CVA6Cfg.XF8, CVA6Cfg.XF16ALT},
+        IntFmtMask: {
+          CVA6Cfg.XFVec && CVA6Cfg.XF8,
+          CVA6Cfg.XFVec && (CVA6Cfg.XF16 || CVA6Cfg.XF16ALT),
+          1'b1,
+          1'b1
+        }
+    };
+
+    // Implementation (number of registers etc)
+    localparam fpnew_pkg::fpu_implementation_t FPU_IMPLEMENTATION = '{
+        PipeRegs: '{  // FP32, FP64, FP16, FP8, FP16alt
+            '{
+                unsigned'(LAT_COMP_FP32),
+                unsigned'(LAT_COMP_FP64),
+                unsigned'(LAT_COMP_FP16),
+                unsigned'(LAT_COMP_FP8),
+                unsigned'(LAT_COMP_FP16ALT)
+            },  // ADDMUL
+            '{default: unsigned'(LAT_DIVSQRT)},  // DIVSQRT
+            '{default: unsigned'(LAT_NONCOMP)},  // NONCOMP
+            '{default: unsigned'(LAT_CONV)}
+        },  // CONV
+        UnitTypes: '{
+            '{default: fpnew_pkg::PARALLEL},  // ADDMUL
+            '{default: fpnew_pkg::MERGED},  // DIVSQRT
+            '{default: fpnew_pkg::PARALLEL},  // NONCOMP
+            '{default: fpnew_pkg::MERGED}
+        },  // CONV
+        PipeConfig: fpnew_pkg::DISTRIBUTED
+    };
+
+    //-------------------------------------------------
+    // Inputs to the FPU and protocol inversion buffer
+    //-------------------------------------------------
+    logic [CVA6Cfg.FLen-1:0] operand_a_d, operand_a_q, operand_a;
+    logic [CVA6Cfg.FLen-1:0] operand_b_d, operand_b_q, operand_b;
+    logic [CVA6Cfg.FLen-1:0] operand_c_d, operand_c_q, operand_c;
+    logic [OPBITS-1:0] fpu_op_d, fpu_op_q, fpu_op;
+    logic fpu_op_mod_d, fpu_op_mod_q, fpu_op_mod;
+    logic [FMTBITS-1:0] fpu_srcfmt_d, fpu_srcfmt_q, fpu_srcfmt;
+    logic [FMTBITS-1:0] fpu_dstfmt_d, fpu_dstfmt_q, fpu_dstfmt;
+    logic [IFMTBITS-1:0] fpu_ifmt_d, fpu_ifmt_q, fpu_ifmt;
+    logic [2:0] fpu_rm_d, fpu_rm_q, fpu_rm;
+    logic fpu_vec_op_d, fpu_vec_op_q, fpu_vec_op;
+
+    logic [CVA6Cfg.TRANS_ID_BITS-1:0] fpu_tag_d, fpu_tag_q, fpu_tag;
+
+    logic fpu_in_ready, fpu_in_valid;
+    logic fpu_out_ready, fpu_out_valid;
+
+    logic [4:0] fpu_status;
+
+    // FSM to handle protocol inversion
+    logic hold_inputs;
+    logic use_hold;
+
+    //-----------------------------
+    // Translate inputs
+    //-----------------------------
+
+    always_comb begin : input_translation
+
+      automatic logic vec_replication;  // control honoring of replication flag
+      automatic logic replicate_c;  // replicate operand C instead of B (for ADD/SUB)
+      automatic logic check_ah;  // Decide for AH from RM field encoding
+
+      // Default Values
+      operand_a_d     = operand_a_i;
+      operand_b_d     = operand_b_i;  // immediates come through this port unless used as operand
+      operand_c_d     = operand_c_i;  // immediates come through this port unless used as operand
+      fpu_op_d        = fpnew_pkg::SGNJ;  // sign injection by default
+      fpu_op_mod_d    = 1'b0;
+      fpu_dstfmt_d    = fpnew_pkg::FP32;
+      fpu_ifmt_d      = fpnew_pkg::INT32;
+      fpu_rm_d        = fpu_rm_i;
+      fpu_vec_op_d    = CVA6Cfg.XFVec && (fu_data_i.fu == FPU_VEC);
+      fpu_tag_d       = fu_data_i.trans_id;
+      vec_replication = fpu_rm_i[0];  // replication bit is sent via rm field
+      replicate_c     = 1'b0;
+      check_ah        = 1'b0;  // whether set scalar AH encoding from MSB of rm_i
+
+      // Scalar Rounding Modes - some ops encode inside RM but use smaller range
+      if (!(fpu_rm_i inside {[3'b000 : 3'b100]})) fpu_rm_d = fpu_frm_i;
+
+      // Vectorial ops always consult FRM
+      if (fpu_vec_op_d) fpu_rm_d = fpu_frm_i;
+
+      // Formats
+      unique case (fpu_fmt_i)
+        // FP32
+        2'b00:   fpu_dstfmt_d = fpnew_pkg::FP32;
+        // FP64 or FP16ALT (vectorial)
+        2'b01:   fpu_dstfmt_d = fpu_vec_op_d ? fpnew_pkg::FP16ALT : fpnew_pkg::FP64;
+        // FP16 or FP16ALT (scalar)
+        2'b10: begin
+          if (CVA6Cfg.XF16ALT && !fpu_vec_op_d && fpu_rm_i == 3'b101) fpu_dstfmt_d = fpnew_pkg::FP16ALT;
+          else fpu_dstfmt_d = fpnew_pkg::FP16;
+        end
+        // FP8
+        default: fpu_dstfmt_d = fpnew_pkg::FP8;
+      endcase
+
+      // By default, set src=dst
+      fpu_srcfmt_d = fpu_dstfmt_d;
+
+      // Operations (this can modify the rounding mode field and format!)
+      unique case (fu_data_i.operation)
+        // Addition
+        FADD: begin
+          fpu_op_d    = fpnew_pkg::ADD;
+          replicate_c = 1'b1; // second operand is in C
+        end
+        // Subtraction is modified ADD
+        FSUB: begin
+          fpu_op_d     = fpnew_pkg::ADD;
+          fpu_op_mod_d = 1'b1;
+          replicate_c  = 1'b1;  // second operand is in C
+        end
+        // Multiplication
+        FMUL:    fpu_op_d = fpnew_pkg::MUL;
+        // Division
+        FDIV:    fpu_op_d = fpnew_pkg::DIV;
+        // Min/Max - OP is encoded in rm (000-001)
+        FMIN_MAX: begin
+          fpu_op_d = fpnew_pkg::MINMAX;
+          fpu_rm_d = {1'b0, fpu_rm_i[1:0]};  // mask out AH encoding bit
+          check_ah = 1'b1;  // AH has RM MSB encoding
+        end
+        // Square Root
+        FSQRT:   fpu_op_d = fpnew_pkg::SQRT;
+        // Fused Multiply Add
+        FMADD:   fpu_op_d = fpnew_pkg::FMADD;
+        // Fused Multiply Subtract is modified FMADD
+        FMSUB: begin
+          fpu_op_d     = fpnew_pkg::FMADD;
+          fpu_op_mod_d = 1'b1;
+        end
+        // Fused Negated Multiply Subtract
+        FNMSUB:  fpu_op_d = fpnew_pkg::FNMSUB;
+        // Fused Negated Multiply Add is modified FNMSUB
+        FNMADD: begin
+          fpu_op_d     = fpnew_pkg::FNMSUB;
+          fpu_op_mod_d = 1'b1;
+        end
+        // Float to Int Cast - Op encoded in lowest two imm bits or rm
+        FCVT_F2I: begin
+          fpu_op_d = fpnew_pkg::F2I;
+          // Vectorial Ops encoded in R bit
+          if (CVA6Cfg.XFVec && fpu_vec_op_d) begin
+            fpu_op_mod_d    = fpu_rm_i[0];
+            vec_replication = 1'b0;  // no replication, R bit used for op
+            unique case (fpu_fmt_i)
+              2'b00: fpu_ifmt_d = fpnew_pkg::INT32;
+              2'b01, 2'b10: fpu_ifmt_d = fpnew_pkg::INT16;
+              2'b11: fpu_ifmt_d = fpnew_pkg::INT8;
+            endcase
+            // Scalar casts encoded in imm
+          end else begin
+            fpu_op_mod_d = operand_c_i[0];
+            if (operand_c_i[1]) fpu_ifmt_d = fpnew_pkg::INT64;
+            else fpu_ifmt_d = fpnew_pkg::INT32;
+          end
+        end
+        // Int to Float Cast - Op encoded in lowest two imm bits or rm
+        FCVT_I2F: begin
+          fpu_op_d = fpnew_pkg::I2F;
+          // Vectorial Ops encoded in R bit
+          if (CVA6Cfg.XFVec && fpu_vec_op_d) begin
+            fpu_op_mod_d    = fpu_rm_i[0];
+            vec_replication = 1'b0;  // no replication, R bit used for op
+            unique case (fpu_fmt_i)
+              2'b00: fpu_ifmt_d = fpnew_pkg::INT32;
+              2'b01, 2'b10: fpu_ifmt_d = fpnew_pkg::INT16;
+              2'b11: fpu_ifmt_d = fpnew_pkg::INT8;
+            endcase
+            // Scalar casts encoded in imm
+          end else begin
+            fpu_op_mod_d = operand_c_i[0];
+            if (operand_c_i[1]) fpu_ifmt_d = fpnew_pkg::INT64;
+            else fpu_ifmt_d = fpnew_pkg::INT32;
+          end
+        end
+        // Float to Float Cast - Source format encoded in lowest two/three imm bits
+        FCVT_F2F: begin
+          fpu_op_d = fpnew_pkg::F2F;
+          // Vectorial ops encoded in lowest two imm bits
+          if (CVA6Cfg.XFVec && fpu_vec_op_d) begin
+            vec_replication = 1'b0;  // no replication for casts (not needed)
+            unique case (operand_c_i[1:0])
+              2'b00: fpu_srcfmt_d = fpnew_pkg::FP32;
+              2'b01: fpu_srcfmt_d = fpnew_pkg::FP16ALT;
+              2'b10: fpu_srcfmt_d = fpnew_pkg::FP16;
+              2'b11: fpu_srcfmt_d = fpnew_pkg::FP8;
+            endcase
+            // Scalar ops encoded in lowest three imm bits
+          end else begin
+            unique case (operand_c_i[2:0])
+              3'b000:  fpu_srcfmt_d = fpnew_pkg::FP32;
+              3'b001:  fpu_srcfmt_d = fpnew_pkg::FP64;
+              3'b010:  fpu_srcfmt_d = fpnew_pkg::FP16;
+              3'b110:  if (CVA6Cfg.XF16ALT) fpu_srcfmt_d = fpnew_pkg::FP16ALT;
+              3'b011:  if (CVA6Cfg.XF8) fpu_srcfmt_d = fpnew_pkg::FP8;
+              default: ;  // Do nothing
+            endcase
+          end
+        end
+        // Scalar Sign Injection - op encoded in rm (000-010)
+        FSGNJ: begin
+          fpu_op_d = fpnew_pkg::SGNJ;
+          fpu_rm_d = {1'b0, fpu_rm_i[1:0]};  // mask out AH encoding bit
+          check_ah = 1'b1;  // AH has RM MSB encoding
+        end
+        // Move from FPR to GPR - mapped to SGNJ-passthrough since no recoding
+        FMV_F2X: begin
+          fpu_op_d        = fpnew_pkg::SGNJ;
+          fpu_rm_d        = 3'b011;  // passthrough without checking nan-box
+          fpu_op_mod_d    = 1'b1;  // no NaN-Boxing
+          check_ah        = 1'b1;  // AH has RM MSB encoding
+          vec_replication = 1'b0;  // no replication, we set second operand
+        end
+        // Move from GPR to FPR - mapped to NOP since no recoding
+        FMV_X2F: begin
+          fpu_op_d        = fpnew_pkg::SGNJ;
+          fpu_rm_d        = 3'b011;  // passthrough without checking nan-box
+          check_ah        = 1'b1;  // AH has RM MSB encoding
+          vec_replication = 1'b0;  // no replication, we set second operand
+        end
+        // Scalar Comparisons - op encoded in rm (000-010)
+        FCMP: begin
+          fpu_op_d = fpnew_pkg::CMP;
+          fpu_rm_d = {1'b0, fpu_rm_i[1:0]};  // mask out AH encoding bit
+          check_ah = 1'b1;  // AH has RM MSB encoding
+        end
+        // Classification
+        FCLASS: begin
+          fpu_op_d = fpnew_pkg::CLASSIFY;
+          fpu_rm_d = {
+            1'b0, fpu_rm_i[1:0]
+          };  // mask out AH encoding bit - CLASS doesn't care anyways
+          check_ah = 1'b1;  // AH has RM MSB encoding
+        end
+        // Vectorial Minimum - set up scalar encoding in rm
+        VFMIN: begin
+          fpu_op_d = fpnew_pkg::MINMAX;
+          fpu_rm_d = 3'b000;  // min
+        end
+        // Vectorial Maximum - set up scalar encoding in rm
+        VFMAX: begin
+          fpu_op_d = fpnew_pkg::MINMAX;
+          fpu_rm_d = 3'b001;  // max
+        end
+        // Vectorial Sign Injection - set up scalar encoding in rm
+        VFSGNJ: begin
+          fpu_op_d = fpnew_pkg::SGNJ;
+          fpu_rm_d = 3'b000;  // sgnj
+        end
+        // Vectorial Negated Sign Injection - set up scalar encoding in rm
+        VFSGNJN: begin
+          fpu_op_d = fpnew_pkg::SGNJ;
+          fpu_rm_d = 3'b001;  // sgnjn
+        end
+        // Vectorial Xored Sign Injection - set up scalar encoding in rm
+        VFSGNJX: begin
+          fpu_op_d = fpnew_pkg::SGNJ;
+          fpu_rm_d = 3'b010;  // sgnjx
+        end
+        // Vectorial Equals - set up scalar encoding in rm
+        VFEQ: begin
+          fpu_op_d = fpnew_pkg::CMP;
+          fpu_rm_d = 3'b010;  // eq
+        end
+        // Vectorial Not Equals - set up scalar encoding in rm
+        VFNE: begin
+          fpu_op_d     = fpnew_pkg::CMP;
+          fpu_op_mod_d = 1'b1;  // invert output
+          fpu_rm_d     = 3'b010;  // eq
+        end
+        // Vectorial Less Than - set up scalar encoding in rm
+        VFLT: begin
+          fpu_op_d = fpnew_pkg::CMP;
+          fpu_rm_d = 3'b001;  // lt
+        end
+        // Vectorial Greater or Equal - set up scalar encoding in rm
+        VFGE: begin
+          fpu_op_d     = fpnew_pkg::CMP;
+          fpu_op_mod_d = 1'b1;  // invert output
+          fpu_rm_d     = 3'b001;  // lt
+        end
+        // Vectorial Less or Equal - set up scalar encoding in rm
+        VFLE: begin
+          fpu_op_d = fpnew_pkg::CMP;
+          fpu_rm_d = 3'b000;  // le
+        end
+        // Vectorial Greater Than - set up scalar encoding in rm
+        VFGT: begin
+          fpu_op_d     = fpnew_pkg::CMP;
+          fpu_op_mod_d = 1'b1;  // invert output
+          fpu_rm_d     = 3'b000;  // le
+        end
+        // Vectorial Convert-and-Pack from FP32, lower 4 entries
+        VFCPKAB_S: begin
+          fpu_op_d        = fpnew_pkg::CPKAB;
+          fpu_op_mod_d    = fpu_rm_i[0];  // A/B selection from R bit
+          vec_replication = 1'b0;  // no replication, R bit used for op
+          fpu_srcfmt_d    = fpnew_pkg::FP32;  // Cast from FP32
+        end
+        // Vectorial Convert-and-Pack from FP32, upper 4 entries
+        VFCPKCD_S: begin
+          fpu_op_d        = fpnew_pkg::CPKCD;
+          fpu_op_mod_d    = fpu_rm_i[0];  // C/D selection from R bit
+          vec_replication = 1'b0;  // no replication, R bit used for op
+          fpu_srcfmt_d    = fpnew_pkg::FP32;  // Cast from FP32
+        end
+        // Vectorial Convert-and-Pack from FP64, lower 4 entries
+        VFCPKAB_D: begin
+          fpu_op_d        = fpnew_pkg::CPKAB;
+          fpu_op_mod_d    = fpu_rm_i[0];  // A/B selection from R bit
+          vec_replication = 1'b0;  // no replication, R bit used for op
+          fpu_srcfmt_d    = fpnew_pkg::FP64;  // Cast from FP64
+        end
+        // Vectorial Convert-and-Pack from FP64, upper 4 entries
+        VFCPKCD_D: begin
+          fpu_op_d        = fpnew_pkg::CPKCD;
+          fpu_op_mod_d    = fpu_rm_i[0];  // C/D selection from R bit
+          vec_replication = 1'b0;  // no replication, R bit used for op
+          fpu_srcfmt_d    = fpnew_pkg::FP64;  // Cast from FP64
+        end
+        // No changes per default
+        default: ;  //nothing
+      endcase
+
+      // Scalar AH encoding fixing
+      if (!fpu_vec_op_d && check_ah) if (fpu_rm_i[2]) fpu_dstfmt_d = fpnew_pkg::FP16ALT;
+
+      // Replication
+      if (fpu_vec_op_d && vec_replication) begin
+        if (replicate_c) begin
+          unique case (fpu_dstfmt_d)
+            fpnew_pkg::FP32: operand_c_d = CVA6Cfg.RVD ? {2{operand_c_i[31:0]}} : operand_c_i;
+            fpnew_pkg::FP16, fpnew_pkg::FP16ALT:
+            operand_c_d = CVA6Cfg.RVD ? {4{operand_c_i[15:0]}} : {2{operand_c_i[15:0]}};
+            fpnew_pkg::FP8:
+            operand_c_d = CVA6Cfg.RVD ? {8{operand_c_i[7:0]}} : {4{operand_c_i[7:0]}};
+            default: ;  // Do nothing
+          endcase  // fpu_dstfmt_d
+        end else begin
+          unique case (fpu_dstfmt_d)
+            fpnew_pkg::FP32: operand_b_d = CVA6Cfg.RVD ? {2{operand_b_i[31:0]}} : operand_b_i;
+            fpnew_pkg::FP16, fpnew_pkg::FP16ALT:
+            operand_b_d = CVA6Cfg.RVD ? {4{operand_b_i[15:0]}} : {2{operand_b_i[15:0]}};
+            fpnew_pkg::FP8:
+            operand_b_d = CVA6Cfg.RVD ? {8{operand_b_i[7:0]}} : {4{operand_b_i[7:0]}};
+            default: ;  // Do nothing
+          endcase  // fpu_dstfmt_d
+        end
+      end
+    end
+
+
+    //---------------------------------------------------------
+    // Upstream protocol inversion: InValid depends on InReady
+    //---------------------------------------------------------
+
+    always_comb begin : p_inputFSM
+      // Default Values
+      fpu_ready_o  = 1'b0;
+      fpu_in_valid = 1'b0;
+      hold_inputs  = 1'b0;  // hold register disabled
+      use_hold     = 1'b0;  // inputs go directly to unit
+      state_d      = state_q;  // stay in the same state
+
+      // FSM
+      unique case (state_q)
+        // Default state, ready for instructions
+        READY: begin
+          fpu_ready_o  = 1'b1;  // Act as if FPU ready
+          fpu_in_valid = fpu_valid_i;  // Forward input valid to FPU
+          // There is a transaction but the FPU can't handle it
+          if (fpu_valid_i & ~fpu_in_ready) begin
+            fpu_ready_o = 1'b0;  // No token given to Issue
+            hold_inputs = 1'b1;  // save inputs to the holding register
+            state_d     = STALL;  // stall future incoming requests
+          end
+        end
+        // We're stalling the upstream (ready=0)
+        STALL: begin
+          fpu_in_valid = 1'b1;  // we have data for the FPU
+          use_hold     = 1'b1;  // the data comes from the hold reg
+          // Wait until it's consumed
+          if (fpu_in_ready) begin
+            fpu_ready_o = 1'b1;  // Give a token to issue
+            state_d     = READY;  // accept future requests
+          end
+        end
+        // Default: emit default values
+        default: ;
+      endcase
+
+      // Flushing will override issue and go back to idle
+      if (flush_i) begin
+        state_d = READY;
+      end
+
+    end
+
+    // Buffer register and FSM state holding
+    always_ff @(posedge clk_i or negedge rst_ni) begin : fp_hold_reg
+      if (~rst_ni) begin
+        state_q      <= READY;
+        operand_a_q  <= '0;
+        operand_b_q  <= '0;
+        operand_c_q  <= '0;
+        fpu_op_q     <= '0;
+        fpu_op_mod_q <= '0;
+        fpu_srcfmt_q <= '0;
+        fpu_dstfmt_q <= '0;
+        fpu_ifmt_q   <= '0;
+        fpu_rm_q     <= '0;
+        fpu_vec_op_q <= '0;
+        fpu_tag_q    <= '0;
+      end else begin
+        state_q <= state_d;
+        // Hold register is [TRIGGERED] by FSM
+        if (hold_inputs) begin
+          operand_a_q  <= operand_a_d;
+          operand_b_q  <= operand_b_d;
+          operand_c_q  <= operand_c_d;
+          fpu_op_q     <= fpu_op_d;
+          fpu_op_mod_q <= fpu_op_mod_d;
+          fpu_srcfmt_q <= fpu_srcfmt_d;
+          fpu_dstfmt_q <= fpu_dstfmt_d;
+          fpu_ifmt_q   <= fpu_ifmt_d;
+          fpu_rm_q     <= fpu_rm_d;
+          fpu_vec_op_q <= fpu_vec_op_d;
+          fpu_tag_q    <= fpu_tag_d;
+        end
+      end
+    end
+
+    // Select FPU input data: from register if valid data in register, else directly from input
+    assign operand_a  = use_hold ? operand_a_q : operand_a_d;
+    assign operand_b  = use_hold ? operand_b_q : operand_b_d;
+    assign operand_c  = use_hold ? operand_c_q : operand_c_d;
+    assign fpu_op     = use_hold ? fpu_op_q : fpu_op_d;
+    assign fpu_op_mod = use_hold ? fpu_op_mod_q : fpu_op_mod_d;
+    assign fpu_srcfmt = use_hold ? fpu_srcfmt_q : fpu_srcfmt_d;
+    assign fpu_dstfmt = use_hold ? fpu_dstfmt_q : fpu_dstfmt_d;
+    assign fpu_ifmt   = use_hold ? fpu_ifmt_q : fpu_ifmt_d;
+    assign fpu_rm     = use_hold ? fpu_rm_q : fpu_rm_d;
+    assign fpu_vec_op = use_hold ? fpu_vec_op_q : fpu_vec_op_d;
+    assign fpu_tag    = use_hold ? fpu_tag_q : fpu_tag_d;
+
+    // Consolidate operands
+    logic [2:0][CVA6Cfg.FLen-1:0] fpu_operands;
+
+    assign fpu_operands[0] = operand_a;
+    assign fpu_operands[1] = operand_b;
+    assign fpu_operands[2] = operand_c;
+
+    //---------------
+    // FPU instance
+    //---------------
+
+    fpnew_top #(
+        .Features      (FPU_FEATURES),
+        .Implementation(FPU_IMPLEMENTATION),
+        .TagType       (logic [CVA6Cfg.TRANS_ID_BITS-1:0])
+    ) i_fpnew_bulk (
+        .clk_i,
+        .rst_ni,
+        .operands_i    (fpu_operands),
+        .rnd_mode_i    (fpnew_pkg::roundmode_e'(fpu_rm)),
+        .op_i          (fpnew_pkg::operation_e'(fpu_op)),
+        .op_mod_i      (fpu_op_mod),
+        .src_fmt_i     (fpnew_pkg::fp_format_e'(fpu_srcfmt)),
+        .dst_fmt_i     (fpnew_pkg::fp_format_e'(fpu_dstfmt)),
+        .int_fmt_i     (fpnew_pkg::int_format_e'(fpu_ifmt)),
+        .vectorial_op_i(fpu_vec_op),
+        .tag_i         (fpu_tag),
+        .simd_mask_i   (1'b1),
+        .in_valid_i    (fpu_in_valid),
+        .in_ready_o    (fpu_in_ready),
+        .flush_i,
+        .result_o,
+        .status_o      (fpu_status),
+        .tag_o         (fpu_trans_id_o),
+        .out_valid_o   (fpu_out_valid),
+        .out_ready_i   (fpu_out_ready),
+        .busy_o        (  /* unused */),
+        .early_valid_o (fpu_early_valid_o)
+    );
+
+    // Pack status flag into exception cause, tval ignored in wb, exception is always invalid
+    assign fpu_exception_o.cause = {59'h0, fpu_status};
+    assign fpu_exception_o.tval  = '0;
+    assign fpu_exception_o.tval2 = '0;
+    assign fpu_exception_o.tinst = '0;
+    assign fpu_exception_o.gva   = '0;
+    assign fpu_exception_o.valid = 1'b0;
+
+    // Downstream write port is dedicated to FPU and always ready
+    assign fpu_out_ready = 1'b1;
+
+    // Downstream valid from unit
+    assign fpu_valid_o = fpu_out_valid;
+
+  end
+endmodule

--- a/modules/cva6-cvfpu/riscv_pkg.sv
+++ b/modules/cva6-cvfpu/riscv_pkg.sv
@@ -1,0 +1,1023 @@
+/* Copyright 2018 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the “License”); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * File:   riscv_pkg.sv
+ * Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+ * Date:   30.6.2017
+ *
+ * Description: Common RISC-V definitions.
+ */
+
+package riscv;
+
+  // ----------------------
+  // Import cva6 config from cva6_config_pkg
+  // ----------------------
+  // FIXME stop using them from CoreV-Verif and HPDCache
+  // Then remove them from this package
+  localparam XLEN = cva6_config_pkg::CVA6ConfigXlen;
+  localparam PLEN = (XLEN == 32) ? 34 : 56;
+
+  // --------------------
+  // Privilege Spec
+  // --------------------
+  typedef enum logic [1:0] {
+    PRIV_LVL_M  = 2'b11,
+    PRIV_LVL_HS = 2'b10,
+    PRIV_LVL_S  = 2'b01,
+    PRIV_LVL_U  = 2'b00
+  } priv_lvl_t;
+
+  // type which holds xlen
+  typedef enum logic [1:0] {
+    XLEN_32  = 2'b01,
+    XLEN_64  = 2'b10,
+    XLEN_128 = 2'b11
+  } xlen_e;
+
+  typedef enum logic [1:0] {
+    Off     = 2'b00,
+    Initial = 2'b01,
+    Clean   = 2'b10,
+    Dirty   = 2'b11
+  } xs_t;
+
+  typedef enum logic [1:0] {
+    CBIE_ILLEGAL = 2'b00, // execution of CBO.INVAL in lower privilege mode causes illegal instruction / virtual instruction exception
+    CBIE_FLUSH = 2'b01,  // CBO.INVAL causes flush
+    CBIE_RSVD = 2'b10,  // reserved
+    CBIE_INVAL = 2'b11  // CBO.INVAL causes invalidate
+  } cbie_t;
+
+  typedef struct packed {
+    logic sd;  // signal dirty state - read-only
+    logic [62:34] wpri6;  // writes preserved reads ignored
+    xlen_e uxl;  // variable user mode xlen - hardwired to zero
+    logic [11:0] wpri5;  // writes preserved reads ignored
+    logic mxr;  // make executable readable
+    logic sum;  // permit supervisor user memory access
+    logic wpri4;  // writes preserved reads ignored
+    xs_t xs;  // extension register - hardwired to zero
+    xs_t fs;  // floating point extension register
+    logic [1:0] wpri3;  // writes preserved reads ignored
+    xs_t vs;  // vector extension register
+    logic spp;  // holds the previous privilege mode up to supervisor
+    logic wpri2;  // writes preserved reads ignored
+    logic mpie;  // machine interrupts enable bit active prior to trap
+    logic         ube;    // UBE controls whether explicit load and store memory accesses made from U-mode are little-endian (UBE=0) or big-endian (UBE=1)
+    logic spie;  // supervisor interrupts enable bit active prior to trap
+    logic [2:0] wpri1;  // writes preserved reads ignored
+    logic sie;  // supervisor interrupts enable
+    logic wpri0;  // writes preserved reads ignored
+  } sstatus_rv_t;
+
+  typedef struct packed {
+    logic [63:34] wpri4;  // writes preserved reads ignored
+    xlen_e        vsxl;   // variable virtual supervisor mode xlen - hardwired to zero
+    logic [8:0]   wpri3;  // floating point extension register
+    logic         vtsr;   // virtual trap sret
+    logic         vtw;    // virtual time wait
+    logic         vtvm;   // virtual trap virtual memory
+    logic [1:0]   wpri2;  // writes preserved reads ignored
+    logic [5:0]   vgein;  // virtual guest external interrupt number
+    logic [1:0]   wpri1;  // writes preserved reads ignored
+    logic         hu;     // virtual-machine load/store instructions enable in U-mode
+    logic         spvp;   // supervisor previous virtual privilege
+    logic         spv;    // supervisor previous virtualization mode
+    logic         gva;    // variable set when trap writes to stval
+    logic         vsbe;   // endianness of explicit memory accesses made from VS-mode
+    logic [4:0]   wpri0;  // writes preserved reads ignored
+  } hstatus_rv_t;
+
+  typedef struct packed {
+    logic sd;  // signal dirty state - read-only
+    logic [62:40] wpri4;  // writes preserved reads ignored
+    logic mpv;  // machine previous virtualization mode
+    logic gva;  // variable set when trap writes to stval
+    logic mbe;  // endianness memory accesses made from M-mode
+    logic sbe;  // endianness memory accesses made from S-mode
+    xlen_e sxl;  // variable supervisor mode xlen - hardwired to zero
+    xlen_e uxl;  // variable user mode xlen - hardwired to zero
+    logic [8:0] wpri3;  // writes preserved reads ignored
+    logic tsr;  // trap sret
+    logic tw;  // time wait
+    logic tvm;  // trap virtual memory
+    logic mxr;  // make executable readable
+    logic sum;  // permit supervisor user memory access
+    logic mprv;  // modify privilege - privilege level for ld/st
+    xs_t xs;  // extension register - hardwired to zero
+    xs_t fs;  // floating point extension register
+    priv_lvl_t mpp;  // holds the previous privilege mode up to machine
+    xs_t vs;  // vector extension register
+    logic spp;  // holds the previous privilege mode up to supervisor
+    logic mpie;  // machine interrupts enable bit active prior to trap
+    logic         ube;    // UBE controls whether explicit load and store memory accesses made from U-mode are little-endian (UBE=0) or big-endian (UBE=1)
+    logic spie;  // supervisor interrupts enable bit active prior to trap
+    logic wpri2;  // writes preserved reads ignored
+    logic mie;  // machine interrupts enable
+    logic wpri1;  // writes preserved reads ignored
+    logic sie;  // supervisor interrupts enable
+    logic wpri0;  // writes preserved reads ignored
+  } mstatus_rv_t;
+
+  typedef struct packed {
+    logic        stce;   // not implemented - requires Sctc extension
+    logic        pbmte;  // not implemented - requires Svpbmt extension
+    logic [61:8] wpri1;  // writes preserved reads ignored
+    logic        cbze;   // not implemented - requires Zicboz extension
+    logic        cbcfe;  // not implemented - requires Zicbom extension
+    logic [1:0]  cbie;   // not implemented - requires Zicbom extension
+    logic [2:0]  wpri0;  // writes preserved reads ignored
+    logic        fiom;   // fence of I/O implies memory
+  } envcfg_rv_t;
+
+  // --------------------
+  // Instruction Types
+  // --------------------
+  typedef struct packed {
+    logic [31:25] funct7;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rtype_t;
+
+  typedef struct packed {
+    logic [31:27] rs3;
+    logic [26:25] funct2;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } r4type_t;
+
+  typedef struct packed {
+    logic [31:27] funct5;
+    logic [26:25] fmt;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] rm;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rftype_t;  // floating-point
+
+  typedef struct packed {
+    logic [31:30] funct2;
+    logic [29:25] vecfltop;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:14] repl;
+    logic [13:12] vfmt;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } rvftype_t;  // vectorial floating-point
+
+  typedef struct packed {
+    logic [31:20] imm;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } itype_t;
+
+  typedef struct packed {
+    logic [31:25] imm;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  imm0;
+    logic [6:0]   opcode;
+  } stype_t;
+
+  typedef struct packed {
+    logic [31:12] imm;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } utype_t;
+
+  // atomic instructions
+  typedef struct packed {
+    logic [31:27] funct5;
+    logic         aq;
+    logic         rl;
+    logic [24:20] rs2;
+    logic [19:15] rs1;
+    logic [14:12] funct3;
+    logic [11:7]  rd;
+    logic [6:0]   opcode;
+  } atype_t;
+
+  typedef union packed {
+    logic [31:0] instr;
+    rtype_t      rtype;
+    r4type_t     r4type;
+    rftype_t     rftype;
+    rvftype_t    rvftype;
+    itype_t      itype;
+    stype_t      stype;
+    utype_t      utype;
+    atype_t      atype;
+  } instruction_t;
+
+  // --------------------
+  // Opcodes
+  // --------------------
+  // RV32/64G listings:
+  // Quadrant 0
+  localparam OpcodeLoad = 7'b00_000_11;
+  localparam OpcodeLoadFp = 7'b00_001_11;
+  localparam OpcodeCustom0 = 7'b00_010_11;
+  localparam OpcodeMiscMem = 7'b00_011_11;
+  localparam OpcodeOpImm = 7'b00_100_11;
+  localparam OpcodeAuipc = 7'b00_101_11;
+  localparam OpcodeOpImm32 = 7'b00_110_11;
+  // Quadrant 1
+  localparam OpcodeStore = 7'b01_000_11;
+  localparam OpcodeStoreFp = 7'b01_001_11;
+  localparam OpcodeCustom1 = 7'b01_010_11;
+  localparam OpcodeAmo = 7'b01_011_11;
+  localparam OpcodeOp = 7'b01_100_11;
+  localparam OpcodeLui = 7'b01_101_11;
+  localparam OpcodeOp32 = 7'b01_110_11;
+  // Quadrant 2
+  localparam OpcodeMadd = 7'b10_000_11;
+  localparam OpcodeMsub = 7'b10_001_11;
+  localparam OpcodeNmsub = 7'b10_010_11;
+  localparam OpcodeNmadd = 7'b10_011_11;
+  localparam OpcodeOpFp = 7'b10_100_11;
+  localparam OpcodeVec = 7'b10_101_11;
+  localparam OpcodeCustom2 = 7'b10_110_11;
+  // Quadrant 3
+  localparam OpcodeBranch = 7'b11_000_11;
+  localparam OpcodeJalr = 7'b11_001_11;
+  localparam OpcodeRsrvd2 = 7'b11_010_11;
+  localparam OpcodeJal = 7'b11_011_11;
+  localparam OpcodeSystem = 7'b11_100_11;
+  localparam OpcodeRsrvd3 = 7'b11_101_11;
+  localparam OpcodeCustom3 = 7'b11_110_11;
+
+  // RV64C/RV32C listings:
+  // Quadrant 0
+  localparam OpcodeC0 = 2'b00;
+  localparam OpcodeC0Addi4spn = 3'b000;
+  localparam OpcodeC0Fld = 3'b001;
+  localparam OpcodeC0Lw = 3'b010;
+  localparam OpcodeC0Ld = 3'b011;
+  localparam OpcodeC0Zcb = 3'b100;
+  localparam OpcodeC0Fsd = 3'b101;
+  localparam OpcodeC0Sw = 3'b110;
+  localparam OpcodeC0Sd = 3'b111;
+  // Quadrant 1
+  localparam OpcodeC1 = 2'b01;
+  localparam OpcodeC1Addi = 3'b000;
+  localparam OpcodeC1Addiw = 3'b001;  //for RV64I only
+  localparam OpcodeC1Jal = 3'b001;  //for RV32I only
+  localparam OpcodeC1Li = 3'b010;
+  localparam OpcodeC1LuiAddi16sp = 3'b011;
+  localparam OpcodeC1MiscAlu = 3'b100;
+  localparam OpcodeC1J = 3'b101;
+  localparam OpcodeC1Beqz = 3'b110;
+  localparam OpcodeC1Bnez = 3'b111;
+  // Quadrant 2
+  localparam OpcodeC2 = 2'b10;
+  localparam OpcodeC2Slli = 3'b000;
+  localparam OpcodeC2Fldsp = 3'b001;
+  localparam OpcodeC2Lwsp = 3'b010;
+  localparam OpcodeC2Ldsp = 3'b011;
+  localparam OpcodeC2JalrMvAdd = 3'b100;
+  localparam OpcodeC2Fsdsp = 3'b101;
+  localparam OpcodeC2Swsp = 3'b110;
+  localparam OpcodeC2Sdsp = 3'b111;
+
+  // ----------------------
+  // Virtual Memory
+  // ----------------------
+  // memory management, pte for sv39
+  typedef struct packed {
+    logic [9:0] reserved;
+    logic [44-1:0] ppn;  // PPN length for
+    logic [1:0] rsw;
+    logic d;
+    logic a;
+    logic g;
+    logic u;
+    logic x;
+    logic w;
+    logic r;
+    logic v;
+  } pte_t;
+
+  // memory management, pte for sv32
+  typedef struct packed {
+    logic [22-1:0] ppn;  // PPN length for
+    logic [1:0] rsw;
+    logic d;
+    logic a;
+    logic g;
+    logic u;
+    logic x;
+    logic w;
+    logic r;
+    logic v;
+  } pte_sv32_t;
+
+  // ----------------------
+  // Exception Cause Codes
+  // ----------------------
+  localparam logic [XLEN-1:0] INSTR_ADDR_MISALIGNED = 0;
+  localparam logic [XLEN-1:0] INSTR_ACCESS_FAULT    = 1;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ILLEGAL_INSTR = 2;
+  localparam logic [XLEN-1:0] BREAKPOINT = 3;
+  localparam logic [XLEN-1:0] LD_ADDR_MISALIGNED = 4;
+  localparam logic [XLEN-1:0] LD_ACCESS_FAULT = 5;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ST_ADDR_MISALIGNED = 6;
+  localparam logic [XLEN-1:0] ST_ACCESS_FAULT = 7;  // Illegal access as governed by PMPs and PMAs
+  localparam logic [XLEN-1:0] ENV_CALL_UMODE = 8;  // environment call from user mode or virtual user mode
+  localparam logic [XLEN-1:0] ENV_CALL_SMODE = 9;  // environment call from hypervisor-extended supervisor mode
+  localparam logic [XLEN-1:0] ENV_CALL_VSMODE = 10; // environment call from virtual supervisor mode
+  localparam logic [XLEN-1:0] ENV_CALL_MMODE = 11;  // environment call from machine mode
+  localparam logic [XLEN-1:0] INSTR_PAGE_FAULT = 12;  // Instruction page fault
+  localparam logic [XLEN-1:0] LOAD_PAGE_FAULT = 13;  // Load page fault
+  localparam logic [XLEN-1:0] STORE_PAGE_FAULT = 15;  // Store page fault
+  localparam logic [XLEN-1:0] INSTR_GUEST_PAGE_FAULT = 20;  // Instruction guest-page fault
+  localparam logic [XLEN-1:0] LOAD_GUEST_PAGE_FAULT = 21;  // Load guest-page fault
+  localparam logic [XLEN-1:0] VIRTUAL_INSTRUCTION = 22;  // virtual instruction
+  localparam logic [XLEN-1:0] STORE_GUEST_PAGE_FAULT = 23;  // Store guest-page fault
+  localparam logic [XLEN-1:0] DEBUG_REQUEST = 24;  // Debug request
+
+  localparam int unsigned IRQ_S_SOFT = 1;
+  localparam int unsigned IRQ_VS_SOFT = 2;
+  localparam int unsigned IRQ_M_SOFT = 3;
+  localparam int unsigned IRQ_S_TIMER = 5;
+  localparam int unsigned IRQ_VS_TIMER = 6;
+  localparam int unsigned IRQ_M_TIMER = 7;
+  localparam int unsigned IRQ_S_EXT = 9;
+  localparam int unsigned IRQ_VS_EXT = 10;
+  localparam int unsigned IRQ_M_EXT = 11;
+  localparam int unsigned IRQ_HS_EXT = 12;
+
+  localparam logic [31:0] MIP_SSIP = 1 << IRQ_S_SOFT;
+  localparam logic [31:0] MIP_VSSIP = 1 << IRQ_VS_SOFT;
+  localparam logic [31:0] MIP_MSIP = 1 << IRQ_M_SOFT;
+  localparam logic [31:0] MIP_STIP = 1 << IRQ_S_TIMER;
+  localparam logic [31:0] MIP_VSTIP = 1 << IRQ_VS_TIMER;
+  localparam logic [31:0] MIP_MTIP = 1 << IRQ_M_TIMER;
+  localparam logic [31:0] MIP_SEIP = 1 << IRQ_S_EXT;
+  localparam logic [31:0] MIP_VSEIP = 1 << IRQ_VS_EXT;
+  localparam logic [31:0] MIP_MEIP = 1 << IRQ_M_EXT;
+  localparam logic [31:0] MIP_SGEIP = 1 << IRQ_HS_EXT;
+
+  // ----------------------
+  // PseudoInstructions Codes
+  // ----------------------
+  localparam logic [31:0] READ_32_PSEUDOINSTRUCTION = 32'h00002000;
+  localparam logic [31:0] WRITE_32_PSEUDOINSTRUCTION = 32'h00002020;
+  localparam logic [31:0] READ_64_PSEUDOINSTRUCTION = 32'h00003000;
+  localparam logic [31:0] WRITE_64_PSEUDOINSTRUCTION = 32'h00003020;
+
+  // -----
+  // CSRs
+  // -----
+  typedef enum logic [11:0] {
+    // Floating-Point CSRs
+    CSR_FFLAGS           = 12'h001,
+    CSR_FRM              = 12'h002,
+    CSR_FCSR             = 12'h003,
+    //jvt
+    CSR_JVT              = 12'h017,
+    CSR_FTRAN            = 12'h800,
+    // Vector CSRs
+    CSR_VSTART           = 12'h008,
+    CSR_VXSAT            = 12'h009,
+    CSR_VXRM             = 12'h00A,
+    CSR_VCSR             = 12'h00F,
+    CSR_VL               = 12'hC20,
+    CSR_VTYPE            = 12'hC21,
+    CSR_VLENB            = 12'hC22,
+    // Virtual Supervisor Mode CSRs
+    CSR_VSSTATUS         = 12'h200,
+    CSR_VSIE             = 12'h204,
+    CSR_VSTVEC           = 12'h205,
+    CSR_VSSCRATCH        = 12'h240,
+    CSR_VSEPC            = 12'h241,
+    CSR_VSCAUSE          = 12'h242,
+    CSR_VSTVAL           = 12'h243,
+    CSR_VSIP             = 12'h244,
+    CSR_VSATP            = 12'h280,
+    // Supervisor Mode CSRs
+    CSR_SSTATUS          = 12'h100,
+    CSR_SIE              = 12'h104,
+    CSR_STVEC            = 12'h105,
+    CSR_SCOUNTEREN       = 12'h106,
+    CSR_SENVCFG          = 12'h10A,
+    CSR_SSCRATCH         = 12'h140,
+    CSR_SEPC             = 12'h141,
+    CSR_SCAUSE           = 12'h142,
+    CSR_STVAL            = 12'h143,
+    CSR_SIP              = 12'h144,
+    CSR_SATP             = 12'h180,
+    // Hypervisor-extended Supervisor Mode CSRs
+    CSR_HSTATUS          = 12'h600,
+    CSR_HEDELEG          = 12'h602,
+    CSR_HIDELEG          = 12'h603,
+    CSR_HIE              = 12'h604,
+    CSR_HCOUNTEREN       = 12'h606,
+    CSR_HGEIE            = 12'h607,
+    CSR_HTVAL            = 12'h643,
+    CSR_HIP              = 12'h644,
+    CSR_HVIP             = 12'h645,
+    CSR_HTINST           = 12'h64A,
+    CSR_HGEIP            = 12'hE12,
+    CSR_HENVCFG          = 12'h60A,
+    CSR_HENVCFGH         = 12'h61A,
+    CSR_HGATP            = 12'h680,
+    CSR_HCONTEXT         = 12'h6A8,
+    CSR_HTIMEDELTA       = 12'h605,
+    CSR_HTIMEDELTAH      = 12'h615,
+    // Machine Mode CSRs
+    CSR_MSTATUS          = 12'h300,
+    CSR_MISA             = 12'h301,
+    CSR_MEDELEG          = 12'h302,
+    CSR_MIDELEG          = 12'h303,
+    CSR_MIE              = 12'h304,
+    CSR_MTVEC            = 12'h305,
+    CSR_MCOUNTEREN       = 12'h306,
+    CSR_MSTATUSH         = 12'h310,
+    CSR_MCOUNTINHIBIT    = 12'h320,
+    CSR_MHPM_EVENT_3     = 12'h323,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_4     = 12'h324,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_5     = 12'h325,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_6     = 12'h326,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_7     = 12'h327,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_8     = 12'h328,  //Machine performance monitoring Event Selector
+    CSR_MHPM_EVENT_9     = 12'h329,  //Reserved
+    CSR_MHPM_EVENT_10    = 12'h32A,  //Reserved
+    CSR_MHPM_EVENT_11    = 12'h32B,  //Reserved
+    CSR_MHPM_EVENT_12    = 12'h32C,  //Reserved
+    CSR_MHPM_EVENT_13    = 12'h32D,  //Reserved
+    CSR_MHPM_EVENT_14    = 12'h32E,  //Reserved
+    CSR_MHPM_EVENT_15    = 12'h32F,  //Reserved
+    CSR_MHPM_EVENT_16    = 12'h330,  //Reserved
+    CSR_MHPM_EVENT_17    = 12'h331,  //Reserved
+    CSR_MHPM_EVENT_18    = 12'h332,  //Reserved
+    CSR_MHPM_EVENT_19    = 12'h333,  //Reserved
+    CSR_MHPM_EVENT_20    = 12'h334,  //Reserved
+    CSR_MHPM_EVENT_21    = 12'h335,  //Reserved
+    CSR_MHPM_EVENT_22    = 12'h336,  //Reserved
+    CSR_MHPM_EVENT_23    = 12'h337,  //Reserved
+    CSR_MHPM_EVENT_24    = 12'h338,  //Reserved
+    CSR_MHPM_EVENT_25    = 12'h339,  //Reserved
+    CSR_MHPM_EVENT_26    = 12'h33A,  //Reserved
+    CSR_MHPM_EVENT_27    = 12'h33B,  //Reserved
+    CSR_MHPM_EVENT_28    = 12'h33C,  //Reserved
+    CSR_MHPM_EVENT_29    = 12'h33D,  //Reserved
+    CSR_MHPM_EVENT_30    = 12'h33E,  //Reserved
+    CSR_MHPM_EVENT_31    = 12'h33F,  //Reserved
+    CSR_MSCRATCH         = 12'h340,
+    CSR_MEPC             = 12'h341,
+    CSR_MCAUSE           = 12'h342,
+    CSR_MTVAL            = 12'h343,
+    CSR_MIP              = 12'h344,
+    CSR_MTINST           = 12'h34A,
+    CSR_MTVAL2           = 12'h34B,
+    CSR_MENVCFG          = 12'h30A,
+    CSR_MENVCFGH         = 12'h31A,
+    CSR_PMPCFG0          = 12'h3A0,
+    CSR_PMPCFG1          = 12'h3A1,
+    CSR_PMPCFG2          = 12'h3A2,
+    CSR_PMPCFG3          = 12'h3A3,
+    CSR_PMPCFG4          = 12'h3A4,
+    CSR_PMPCFG5          = 12'h3A5,
+    CSR_PMPCFG6          = 12'h3A6,
+    CSR_PMPCFG7          = 12'h3A7,
+    CSR_PMPCFG8          = 12'h3A8,
+    CSR_PMPCFG9          = 12'h3A9,
+    CSR_PMPCFG10         = 12'h3AA,
+    CSR_PMPCFG11         = 12'h3AB,
+    CSR_PMPCFG12         = 12'h3AC,
+    CSR_PMPCFG13         = 12'h3AD,
+    CSR_PMPCFG14         = 12'h3AE,
+    CSR_PMPCFG15         = 12'h3AF,
+    CSR_PMPADDR0         = 12'h3B0,
+    CSR_PMPADDR1         = 12'h3B1,
+    CSR_PMPADDR2         = 12'h3B2,
+    CSR_PMPADDR3         = 12'h3B3,
+    CSR_PMPADDR4         = 12'h3B4,
+    CSR_PMPADDR5         = 12'h3B5,
+    CSR_PMPADDR6         = 12'h3B6,
+    CSR_PMPADDR7         = 12'h3B7,
+    CSR_PMPADDR8         = 12'h3B8,
+    CSR_PMPADDR9         = 12'h3B9,
+    CSR_PMPADDR10        = 12'h3BA,
+    CSR_PMPADDR11        = 12'h3BB,
+    CSR_PMPADDR12        = 12'h3BC,
+    CSR_PMPADDR13        = 12'h3BD,
+    CSR_PMPADDR14        = 12'h3BE,
+    CSR_PMPADDR15        = 12'h3BF,
+    CSR_PMPADDR16        = 12'h3C0,
+    CSR_PMPADDR17        = 12'h3C1,
+    CSR_PMPADDR18        = 12'h3C2,
+    CSR_PMPADDR19        = 12'h3C3,
+    CSR_PMPADDR20        = 12'h3C4,
+    CSR_PMPADDR21        = 12'h3C5,
+    CSR_PMPADDR22        = 12'h3C6,
+    CSR_PMPADDR23        = 12'h3C7,
+    CSR_PMPADDR24        = 12'h3C8,
+    CSR_PMPADDR25        = 12'h3C9,
+    CSR_PMPADDR26        = 12'h3CA,
+    CSR_PMPADDR27        = 12'h3CB,
+    CSR_PMPADDR28        = 12'h3CC,
+    CSR_PMPADDR29        = 12'h3CD,
+    CSR_PMPADDR30        = 12'h3CE,
+    CSR_PMPADDR31        = 12'h3CF,
+    CSR_PMPADDR32        = 12'h3D0,
+    CSR_PMPADDR33        = 12'h3D1,
+    CSR_PMPADDR34        = 12'h3D2,
+    CSR_PMPADDR35        = 12'h3D3,
+    CSR_PMPADDR36        = 12'h3D4,
+    CSR_PMPADDR37        = 12'h3D5,
+    CSR_PMPADDR38        = 12'h3D6,
+    CSR_PMPADDR39        = 12'h3D7,
+    CSR_PMPADDR40        = 12'h3D8,
+    CSR_PMPADDR41        = 12'h3D9,
+    CSR_PMPADDR42        = 12'h3DA,
+    CSR_PMPADDR43        = 12'h3DB,
+    CSR_PMPADDR44        = 12'h3DC,
+    CSR_PMPADDR45        = 12'h3DD,
+    CSR_PMPADDR46        = 12'h3DE,
+    CSR_PMPADDR47        = 12'h3DF,
+    CSR_PMPADDR48        = 12'h3E0,
+    CSR_PMPADDR49        = 12'h3E1,
+    CSR_PMPADDR50        = 12'h3E2,
+    CSR_PMPADDR51        = 12'h3E3,
+    CSR_PMPADDR52        = 12'h3E4,
+    CSR_PMPADDR53        = 12'h3E5,
+    CSR_PMPADDR54        = 12'h3E6,
+    CSR_PMPADDR55        = 12'h3E7,
+    CSR_PMPADDR56        = 12'h3E8,
+    CSR_PMPADDR57        = 12'h3E9,
+    CSR_PMPADDR58        = 12'h3EA,
+    CSR_PMPADDR59        = 12'h3EB,
+    CSR_PMPADDR60        = 12'h3EC,
+    CSR_PMPADDR61        = 12'h3ED,
+    CSR_PMPADDR62        = 12'h3EE,
+    CSR_PMPADDR63        = 12'h3EF,
+    CSR_MVENDORID        = 12'hF11,
+    CSR_MARCHID          = 12'hF12,
+    CSR_MIMPID           = 12'hF13,
+    CSR_MHARTID          = 12'hF14,
+    CSR_MCONFIGPTR       = 12'hF15,
+    CSR_MCYCLE           = 12'hB00,
+    CSR_MCYCLEH          = 12'hB80,
+    CSR_MINSTRET         = 12'hB02,
+    CSR_MINSTRETH        = 12'hB82,
+    //Performance Counters
+    CSR_MHPM_COUNTER_3   = 12'hB03,
+    CSR_MHPM_COUNTER_4   = 12'hB04,
+    CSR_MHPM_COUNTER_5   = 12'hB05,
+    CSR_MHPM_COUNTER_6   = 12'hB06,
+    CSR_MHPM_COUNTER_7   = 12'hB07,
+    CSR_MHPM_COUNTER_8   = 12'hB08,
+    CSR_MHPM_COUNTER_9   = 12'hB09,  // reserved
+    CSR_MHPM_COUNTER_10  = 12'hB0A,  // reserved
+    CSR_MHPM_COUNTER_11  = 12'hB0B,  // reserved
+    CSR_MHPM_COUNTER_12  = 12'hB0C,  // reserved
+    CSR_MHPM_COUNTER_13  = 12'hB0D,  // reserved
+    CSR_MHPM_COUNTER_14  = 12'hB0E,  // reserved
+    CSR_MHPM_COUNTER_15  = 12'hB0F,  // reserved
+    CSR_MHPM_COUNTER_16  = 12'hB10,  // reserved
+    CSR_MHPM_COUNTER_17  = 12'hB11,  // reserved
+    CSR_MHPM_COUNTER_18  = 12'hB12,  // reserved
+    CSR_MHPM_COUNTER_19  = 12'hB13,  // reserved
+    CSR_MHPM_COUNTER_20  = 12'hB14,  // reserved
+    CSR_MHPM_COUNTER_21  = 12'hB15,  // reserved
+    CSR_MHPM_COUNTER_22  = 12'hB16,  // reserved
+    CSR_MHPM_COUNTER_23  = 12'hB17,  // reserved
+    CSR_MHPM_COUNTER_24  = 12'hB18,  // reserved
+    CSR_MHPM_COUNTER_25  = 12'hB19,  // reserved
+    CSR_MHPM_COUNTER_26  = 12'hB1A,  // reserved
+    CSR_MHPM_COUNTER_27  = 12'hB1B,  // reserved
+    CSR_MHPM_COUNTER_28  = 12'hB1C,  // reserved
+    CSR_MHPM_COUNTER_29  = 12'hB1D,  // reserved
+    CSR_MHPM_COUNTER_30  = 12'hB1E,  // reserved
+    CSR_MHPM_COUNTER_31  = 12'hB1F,  // reserved
+    CSR_MHPM_COUNTER_3H  = 12'hB83,
+    CSR_MHPM_COUNTER_4H  = 12'hB84,
+    CSR_MHPM_COUNTER_5H  = 12'hB85,
+    CSR_MHPM_COUNTER_6H  = 12'hB86,
+    CSR_MHPM_COUNTER_7H  = 12'hB87,
+    CSR_MHPM_COUNTER_8H  = 12'hB88,
+    CSR_MHPM_COUNTER_9H  = 12'hB89,  // reserved
+    CSR_MHPM_COUNTER_10H = 12'hB8A,  // reserved
+    CSR_MHPM_COUNTER_11H = 12'hB8B,  // reserved
+    CSR_MHPM_COUNTER_12H = 12'hB8C,  // reserved
+    CSR_MHPM_COUNTER_13H = 12'hB8D,  // reserved
+    CSR_MHPM_COUNTER_14H = 12'hB8E,  // reserved
+    CSR_MHPM_COUNTER_15H = 12'hB8F,  // reserved
+    CSR_MHPM_COUNTER_16H = 12'hB90,  // reserved
+    CSR_MHPM_COUNTER_17H = 12'hB91,  // reserved
+    CSR_MHPM_COUNTER_18H = 12'hB92,  // reserved
+    CSR_MHPM_COUNTER_19H = 12'hB93,  // reserved
+    CSR_MHPM_COUNTER_20H = 12'hB94,  // reserved
+    CSR_MHPM_COUNTER_21H = 12'hB95,  // reserved
+    CSR_MHPM_COUNTER_22H = 12'hB96,  // reserved
+    CSR_MHPM_COUNTER_23H = 12'hB97,  // reserved
+    CSR_MHPM_COUNTER_24H = 12'hB98,  // reserved
+    CSR_MHPM_COUNTER_25H = 12'hB99,  // reserved
+    CSR_MHPM_COUNTER_26H = 12'hB9A,  // reserved
+    CSR_MHPM_COUNTER_27H = 12'hB9B,  // reserved
+    CSR_MHPM_COUNTER_28H = 12'hB9C,  // reserved
+    CSR_MHPM_COUNTER_29H = 12'hB9D,  // reserved
+    CSR_MHPM_COUNTER_30H = 12'hB9E,  // reserved
+    CSR_MHPM_COUNTER_31H = 12'hB9F,  // reserved
+    // Cache Control (platform specifc)
+    CSR_DCACHE           = 12'h7C1,
+    CSR_ICACHE           = 12'h7C0,
+    // Accelerator memory consistency (platform specific)
+    CSR_ACC_CONS         = 12'h7C2,
+    // Triggers
+    CSR_TSELECT          = 12'h7A0,
+    CSR_TDATA1           = 12'h7A1,
+    CSR_TDATA2           = 12'h7A2,
+    CSR_TDATA3           = 12'h7A3,
+    CSR_TINFO            = 12'h7A4,
+    CSR_MCONTEXT         = 12'h7A8,
+    CSR_SCONTEXT         = 12'h5A8,
+    // Debug CSR
+    CSR_DCSR             = 12'h7b0,
+    CSR_DPC              = 12'h7b1,
+    CSR_DSCRATCH0        = 12'h7b2,  // optional
+    CSR_DSCRATCH1        = 12'h7b3,  // optional
+    // Counters and Timers from Zicntr extension (User Mode - R/O Shadows)
+    CSR_CYCLE            = 12'hC00,
+    CSR_CYCLEH           = 12'hC80,
+    CSR_TIME             = 12'hC01,
+    CSR_TIMEH            = 12'hC81,
+    CSR_INSTRET          = 12'hC02,
+    CSR_INSTRETH         = 12'hC82,
+    // Performance counters from Zihpm extension (User Mode - R/O Shadows)
+    CSR_HPM_COUNTER_3    = 12'hC03,
+    CSR_HPM_COUNTER_4    = 12'hC04,
+    CSR_HPM_COUNTER_5    = 12'hC05,
+    CSR_HPM_COUNTER_6    = 12'hC06,
+    CSR_HPM_COUNTER_7    = 12'hC07,
+    CSR_HPM_COUNTER_8    = 12'hC08,
+    CSR_HPM_COUNTER_9    = 12'hC09,  // reserved
+    CSR_HPM_COUNTER_10   = 12'hC0A,  // reserved
+    CSR_HPM_COUNTER_11   = 12'hC0B,  // reserved
+    CSR_HPM_COUNTER_12   = 12'hC0C,  // reserved
+    CSR_HPM_COUNTER_13   = 12'hC0D,  // reserved
+    CSR_HPM_COUNTER_14   = 12'hC0E,  // reserved
+    CSR_HPM_COUNTER_15   = 12'hC0F,  // reserved
+    CSR_HPM_COUNTER_16   = 12'hC10,  // reserved
+    CSR_HPM_COUNTER_17   = 12'hC11,  // reserved
+    CSR_HPM_COUNTER_18   = 12'hC12,  // reserved
+    CSR_HPM_COUNTER_19   = 12'hC13,  // reserved
+    CSR_HPM_COUNTER_20   = 12'hC14,  // reserved
+    CSR_HPM_COUNTER_21   = 12'hC15,  // reserved
+    CSR_HPM_COUNTER_22   = 12'hC16,  // reserved
+    CSR_HPM_COUNTER_23   = 12'hC17,  // reserved
+    CSR_HPM_COUNTER_24   = 12'hC18,  // reserved
+    CSR_HPM_COUNTER_25   = 12'hC19,  // reserved
+    CSR_HPM_COUNTER_26   = 12'hC1A,  // reserved
+    CSR_HPM_COUNTER_27   = 12'hC1B,  // reserved
+    CSR_HPM_COUNTER_28   = 12'hC1C,  // reserved
+    CSR_HPM_COUNTER_29   = 12'hC1D,  // reserved
+    CSR_HPM_COUNTER_30   = 12'hC1E,  // reserved
+    CSR_HPM_COUNTER_31   = 12'hC1F,  // reserved
+    CSR_HPM_COUNTER_3H   = 12'hC83,
+    CSR_HPM_COUNTER_4H   = 12'hC84,
+    CSR_HPM_COUNTER_5H   = 12'hC85,
+    CSR_HPM_COUNTER_6H   = 12'hC86,
+    CSR_HPM_COUNTER_7H   = 12'hC87,
+    CSR_HPM_COUNTER_8H   = 12'hC88,
+    CSR_HPM_COUNTER_9H   = 12'hC89,  // reserved
+    CSR_HPM_COUNTER_10H  = 12'hC8A,  // reserved
+    CSR_HPM_COUNTER_11H  = 12'hC8B,  // reserved
+    CSR_HPM_COUNTER_12H  = 12'hC8C,  // reserved
+    CSR_HPM_COUNTER_13H  = 12'hC8D,  // reserved
+    CSR_HPM_COUNTER_14H  = 12'hC8E,  // reserved
+    CSR_HPM_COUNTER_15H  = 12'hC8F,  // reserved
+    CSR_HPM_COUNTER_16H  = 12'hC90,  // reserved
+    CSR_HPM_COUNTER_17H  = 12'hC91,  // reserved
+    CSR_HPM_COUNTER_18H  = 12'hC92,  // reserved
+    CSR_HPM_COUNTER_19H  = 12'hC93,  // reserved
+    CSR_HPM_COUNTER_20H  = 12'hC94,  // reserved
+    CSR_HPM_COUNTER_21H  = 12'hC95,  // reserved
+    CSR_HPM_COUNTER_22H  = 12'hC96,  // reserved
+    CSR_HPM_COUNTER_23H  = 12'hC97,  // reserved
+    CSR_HPM_COUNTER_24H  = 12'hC98,  // reserved
+    CSR_HPM_COUNTER_25H  = 12'hC99,  // reserved
+    CSR_HPM_COUNTER_26H  = 12'hC9A,  // reserved
+    CSR_HPM_COUNTER_27H  = 12'hC9B,  // reserved
+    CSR_HPM_COUNTER_28H  = 12'hC9C,  // reserved
+    CSR_HPM_COUNTER_29H  = 12'hC9D,  // reserved
+    CSR_HPM_COUNTER_30H  = 12'hC9E,  // reserved
+    CSR_HPM_COUNTER_31H  = 12'hC9F   // reserved
+  } csr_reg_t;
+
+  localparam logic [63:0] SSTATUS_UIE = 'h00000001;
+  localparam logic [63:0] SSTATUS_SIE = 'h00000002;
+  localparam logic [63:0] SSTATUS_SPIE = 'h00000020;
+  localparam logic [63:0] SSTATUS_UBE = 'h00000040;
+  localparam logic [63:0] SSTATUS_SPP = 'h00000100;
+  localparam logic [63:0] SSTATUS_FS = 'h00006000;
+  localparam logic [63:0] SSTATUS_XS = 'h00018000;
+  localparam logic [63:0] SSTATUS_SUM = 'h00040000;
+  localparam logic [63:0] SSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] SSTATUS_UPIE = 'h00000010;
+  localparam logic [63:0] SSTATUS_UXL = 64'h0000000300000000;
+  // CSR Bit Implementation Masks
+
+  function automatic logic [63:0] sstatus_sd(logic IS_XLEN64);
+    return {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
+  endfunction
+
+  localparam logic [63:0] HSTATUS_VSBE = 'h00000020;
+  localparam logic [63:0] HSTATUS_GVA = 'h00000040;
+  localparam logic [63:0] HSTATUS_SPV = 'h00000080;
+  localparam logic [63:0] HSTATUS_SPVP = 'h00000100;
+  localparam logic [63:0] HSTATUS_HU = 'h00000200;
+  localparam logic [63:0] HSTATUS_VGEIN = 'h0003F000;
+  localparam logic [63:0] HSTATUS_VTVM = 'h00100000;
+  localparam logic [63:0] HSTATUS_VTW = 'h00200000;
+  localparam logic [63:0] HSTATUS_VTSR = 'h00400000;
+  localparam logic [63:0] HSTATUS_VSXL = 64'h0000000300000000;
+
+  localparam logic [63:0] MSTATUS_UIE = 'h00000001;
+  localparam logic [63:0] MSTATUS_SIE = 'h00000002;
+  localparam logic [63:0] MSTATUS_HIE = 'h00000004;
+  localparam logic [63:0] MSTATUS_MIE = 'h00000008;
+  localparam logic [63:0] MSTATUS_UPIE = 'h00000010;
+  localparam logic [63:0] MSTATUS_SPIE = 'h00000020;
+  localparam logic [63:0] MSTATUS_UBE = 'h00000040;
+  localparam logic [63:0] MSTATUS_HPIE = 'h00000040;  // TODO - delete old version of H extension
+  localparam logic [63:0] MSTATUS_MPIE = 'h00000080;
+  localparam logic [63:0] MSTATUS_SPP = 'h00000100;
+  localparam logic [63:0] MSTATUS_HPP = 'h00000600;
+  localparam logic [63:0] MSTATUS_MPP = 'h00001800;
+  localparam logic [63:0] MSTATUS_FS = 'h00006000;
+  localparam logic [63:0] MSTATUS_XS = 'h00018000;
+  localparam logic [63:0] MSTATUS_MPRV = 'h00020000;
+  localparam logic [63:0] MSTATUS_SUM = 'h00040000;
+  localparam logic [63:0] MSTATUS_MXR = 'h00080000;
+  localparam logic [63:0] MSTATUS_TVM = 'h00100000;
+  localparam logic [63:0] MSTATUS_TW = 'h00200000;
+  localparam logic [63:0] MSTATUS_TSR = 'h00400000;
+  localparam logic [63:0] MSTATUS_SBE = 64'h1000000000;
+  localparam logic [63:0] MSTATUS_MBE = 64'h2000000000;
+  function automatic logic [63:0] mstatus_uxl(logic IS_XLEN64);
+    return {30'h0000000, IS_XLEN64, IS_XLEN64, 32'h00000000};
+  endfunction
+  function automatic logic [63:0] mstatus_sxl(logic IS_XLEN64);
+    return {28'h0000000, IS_XLEN64, IS_XLEN64, 34'h00000000};
+  endfunction
+  function automatic logic [63:0] mstatus_sd(logic IS_XLEN64);
+    return {IS_XLEN64, 31'h00000000, ~IS_XLEN64, 31'h00000000};
+  endfunction
+  localparam logic [63:0] MSTATUSH_SBE = 'h10;
+  localparam logic [63:0] MSTATUSH_MBE = 'h20;
+
+  localparam logic [63:0] MENVCFG_FIOM = 'h00000001;
+  localparam logic [63:0] MENVCFG_CBIE = 'h00000030;
+  localparam logic [63:0] MENVCFG_CBFE = 'h00000040;
+  localparam logic [63:0] MENVCFG_CBZE = 'h00000080;
+  localparam logic [63:0] MENVCFG_PBMTE = 64'h4000000000000000;
+  localparam logic [63:0] MENVCFG_STCE = 64'h8000000000000000;
+
+
+
+  typedef enum logic [2:0] {
+    CSRRW  = 3'h1,
+    CSRRS  = 3'h2,
+    CSRRC  = 3'h3,
+    CSRRWI = 3'h5,
+    CSRRSI = 3'h6,
+    CSRRCI = 3'h7
+  } csr_op_t;
+
+  // decoded CSR address
+  typedef struct packed {
+    logic [1:0] rw;
+    priv_lvl_t  priv_lvl;
+    logic [7:0] address;
+  } csr_addr_t;
+
+  typedef union packed {
+    csr_reg_t  address;
+    csr_addr_t csr_decode;
+  } csr_t;
+
+  // Floating-Point control and status register (32-bit!)
+  typedef struct packed {
+    logic [31:15] reserved;  // reserved for L extension, return 0 otherwise
+    logic [6:0]   fprec;     // div/sqrt precision control
+    logic [2:0]   frm;       // float rounding mode
+    logic [4:0]   fflags;    // float exception flags
+  } fcsr_t;
+
+  // PMP
+  typedef enum logic [1:0] {
+    OFF   = 2'b00,
+    TOR   = 2'b01,
+    NA4   = 2'b10,
+    NAPOT = 2'b11
+  } pmp_addr_mode_t;
+
+  // PMP Access Type
+  typedef enum logic [2:0] {
+    ACCESS_NONE  = 3'b000,
+    ACCESS_READ  = 3'b001,
+    ACCESS_WRITE = 3'b010,
+    ACCESS_EXEC  = 3'b100
+  } pmp_access_t;
+
+  typedef struct packed {
+    logic x;
+    logic w;
+    logic r;
+  } pmpcfg_access_t;
+
+  // packed struct of a PMP configuration register (8bit)
+  typedef struct packed {
+    logic           locked;       // lock this configuration
+    logic [1:0]     reserved;
+    pmp_addr_mode_t addr_mode;    // Off, TOR, NA4, NAPOT
+    pmpcfg_access_t access_type;
+  } pmpcfg_t;
+
+  // -----
+  // Debug
+  // -----
+  typedef struct packed {
+    logic [31:28] xdebugver;
+    logic [27:18] zero2;
+    logic         ebreakvs;
+    logic         ebreakvu;
+    logic         ebreakm;
+    logic         zero1;
+    logic         ebreaks;
+    logic         ebreaku;
+    logic         stepie;
+    logic         stopcount;
+    logic         stoptime;
+    logic [8:6]   cause;
+    logic         v;
+    logic         mprven;
+    logic         nmip;
+    logic         step;
+    priv_lvl_t    prv;
+  } dcsr_t;
+
+  // Instruction Generation *incomplete*
+  function automatic logic [31:0] jal(logic [4:0] rd, logic [20:0] imm);
+    // OpCode Jal
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, 7'h6f};
+  endfunction
+
+  function automatic logic [31:0] jalr(logic [4:0] rd, logic [4:0] rs1, logic [11:0] offset);
+    // OpCode Jal
+    return {offset[11:0], rs1, 3'b0, rd, 7'h67};
+  endfunction
+
+  function automatic logic [31:0] andi(logic [4:0] rd, logic [4:0] rs1, logic [11:0] imm);
+    // OpCode andi
+    return {imm[11:0], rs1, 3'h7, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] slli(logic [4:0] rd, logic [4:0] rs1, logic [5:0] shamt);
+    // OpCode slli
+    return {6'b0, shamt[5:0], rs1, 3'h1, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] srli(logic [4:0] rd, logic [4:0] rs1, logic [5:0] shamt);
+    // OpCode srli
+    return {6'b0, shamt[5:0], rs1, 3'h5, rd, 7'h13};
+  endfunction
+
+  function automatic logic [31:0] load(logic [2:0] size, logic [4:0] dest, logic [4:0] base,
+                                       logic [11:0] offset);
+    // OpCode Load
+    return {offset[11:0], base, size, dest, 7'h03};
+  endfunction
+
+  function automatic logic [31:0] auipc(logic [4:0] rd, logic [20:0] imm);
+    // OpCode Auipc
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, 7'h17};
+  endfunction
+
+  function automatic logic [31:0] store(logic [2:0] size, logic [4:0] src, logic [4:0] base,
+                                        logic [11:0] offset);
+    // OpCode Store
+    return {offset[11:5], src, base, size, offset[4:0], 7'h23};
+  endfunction
+
+  function automatic logic [31:0] float_load(logic [2:0] size, logic [4:0] dest, logic [4:0] base,
+                                             logic [11:0] offset);
+    // OpCode Load
+    return {offset[11:0], base, size, dest, 7'b00_001_11};
+  endfunction
+
+  function automatic logic [31:0] float_store(logic [2:0] size, logic [4:0] src, logic [4:0] base,
+                                              logic [11:0] offset);
+    // OpCode Store
+    return {offset[11:5], src, base, size, offset[4:0], 7'b01_001_11};
+  endfunction
+
+  function automatic logic [31:0] csrw(csr_reg_t csr, logic [4:0] rs1);
+    // CSRRW, rd, OpCode System
+    return {csr, rs1, 3'h1, 5'h0, 7'h73};
+  endfunction
+
+  function automatic logic [31:0] csrr(csr_reg_t csr, logic [4:0] dest);
+    // rs1, CSRRS, rd, OpCode System
+    return {csr, 5'h0, 3'h2, dest, 7'h73};
+  endfunction
+
+  function automatic logic [31:0] branch(logic [4:0] src2, logic [4:0] src1, logic [2:0] funct3,
+                                         logic [11:0] offset);
+    // OpCode Branch
+    return {offset[11], offset[9:4], src2, src1, funct3, offset[3:0], offset[10], 7'b11_000_11};
+  endfunction
+
+  function automatic logic [31:0] ebreak();
+    return 32'h00100073;
+  endfunction
+
+  function automatic logic [31:0] wfi();
+    return 32'h10500073;
+  endfunction
+
+  function automatic logic [31:0] nop();
+    return 32'h00000013;
+  endfunction
+
+  function automatic logic [31:0] illegal();
+    return 32'h00000000;
+  endfunction
+
+  // This functions converts S-mode CSR addresses into VS-mode CSR addresses
+  // when V=1 (i.e., running in VS-mode).
+  function automatic csr_t convert_vs_access_csr(csr_t csr_addr, logic v);
+    csr_t ret;
+    ret = csr_addr;
+    unique case (csr_addr.address) inside
+      [CSR_SSTATUS : CSR_STVEC], [CSR_SSCRATCH : CSR_SATP]: begin
+        if (v) begin
+          ret.csr_decode.priv_lvl = PRIV_LVL_HS;
+        end
+        return ret;
+      end
+      default: return ret;
+    endcase
+  endfunction
+
+
+  // trace log compatible to spikes commit log feature
+  // pragma translate_off
+  function string spikeCommitLog(logic [63:0] pc, priv_lvl_t priv_lvl, logic [31:0] instr,
+                                 logic [4:0] rd, logic [63:0] result, logic rd_fpr);
+    string rd_s;
+    string instr_word;
+
+    automatic string rf_s = rd_fpr ? "f" : "x";
+
+    if (instr[1:0] != 2'b11) begin
+      instr_word = $sformatf("(0x%h)", instr[15:0]);
+    end else begin
+      instr_word = $sformatf("(0x%h)", instr);
+    end
+
+    if (rd < 10) rd_s = $sformatf("%s %0d", rf_s, rd);
+    else rd_s = $sformatf("%s%0d", rf_s, rd);
+
+    if (rd_fpr || rd != 0) begin
+      // 0 0x0000000080000118 (0xeecf8f93) x31 0x0000000080004000
+      return $sformatf("%d 0x%h %s %s 0x%h\n", priv_lvl, pc, instr_word, rd_s, result);
+    end else begin
+      // 0 0x000000008000019c (0x0040006f)
+      return $sformatf("%d 0x%h %s\n", priv_lvl, pc, instr_word);
+    end
+  endfunction
+
+  typedef struct {
+    byte priv;
+    longint unsigned pc;
+    byte is_fp;
+    byte rd;
+    longint unsigned data;
+    int unsigned instr;
+    byte was_exception;
+  } commit_log_t;
+  // pragma translate_on
+
+endpackage


### PR DESCRIPTION
## Description

As noted in #7, this repository previously cloned CVA6 as a submodule and relied on CVA6's own submodule to pull in the CVFPU. That meant the version of the CVFPU under verification was determined by whatever CVFPU pin CVA6 happened to be using, not by this repository. Given that this is a dedicated CVFPU verification environment, this dependency needed to be removed.

## Changes

**Bender.yml**

- Remove CVA6 from the hardware dependency list
- Add CVFPU as a dependency so that verification is always done on the latest version of the RTL

**modules/**
Copy locally the DUT (`fpu_wrap.sv`) and all the CVA6 files needed to compile it.